### PR TITLE
Fix race condition in cerebrium run log polling

### DIFF
--- a/internal/ui/commands/run.go
+++ b/internal/ui/commands/run.go
@@ -43,7 +43,7 @@ const (
 	// maxDepsSize is the maximum allowed dependencies size (380KB)
 	maxDepsSize = 380 * 1024
 	// finalLogPollAttempts is the number of times to poll for final logs
-	finalLogPollAttempts = 10
+	finalLogPollAttempts = 20
 	// maxLogsToDisplay is the maximum number of logs to display in the UI
 	maxLogsToDisplay = 20
 )


### PR DESCRIPTION
- Add hasSeenLogs tracking to RunView struct
- Don't mark run as complete if status is success but no logs received yet
- Increase final log polling attempts from 10 to 20
- Track when logs are received to set hasSeenLogs flag

This fixes intermittent failures where run completes before logs arrive through the pipeline (Container → Fluent Bit → ClickHouse → API → CLI).

 the CLI would stop polling when it received a 'success' status, before logs made it through the distributed logging pipeline. This change ensures we continue polling for logs even after success status if no logs have been seen yet.