### PR TITLE
feat: Add PyPI package setup for controlled Python distribution

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,100 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 2.0.0)'
+        required: true
+        type: string
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Update version in Python package
+        if: github.event_name == 'release'
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+
+          # Update version in setup.py
+          sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" python-wrapper/setup.py
+
+          # Update version in pyproject.toml
+          sed -i "s/version = \".*\"/version = \"$VERSION\"/" python-wrapper/pyproject.toml
+
+          echo "Updated Python package version to $VERSION"
+
+      - name: Update version (manual trigger)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+
+          # Update version in setup.py
+          sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" python-wrapper/setup.py
+
+          # Update version in pyproject.toml
+          sed -i "s/version = \".*\"/version = \"$VERSION\"/" python-wrapper/pyproject.toml
+
+          echo "Updated Python package version to $VERSION"
+
+      - name: Build Python package
+        working-directory: python-wrapper
+        run: |
+          python -m build
+          ls -la dist/
+
+      - name: Check package
+        working-directory: python-wrapper
+        run: |
+          twine check dist/*
+
+      - name: Publish to Test PyPI
+        if: github.event_name == 'workflow_dispatch'
+        working-directory: python-wrapper
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          twine upload --repository testpypi dist/* --verbose
+
+      - name: Publish to PyPI
+        if: github.event_name == 'release' && !github.event.release.prerelease
+        working-directory: python-wrapper
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload dist/* --verbose
+
+      - name: Test installation from PyPI
+        if: github.event_name == 'release' && !github.event.release.prerelease
+        run: |
+          # Wait for PyPI to update
+          sleep 30
+
+          # Create a clean virtual environment
+          python -m venv test_env
+          source test_env/bin/activate
+
+          # Install from PyPI
+          pip install cerebrium==${{ github.event.release.tag_name#v }}
+
+          # Test that it works
+          cerebrium --version

--- a/python-wrapper/.gitignore
+++ b/python-wrapper/.gitignore
@@ -1,0 +1,7 @@
+*.egg-info/
+dist/
+build/
+*.pyc
+__pycache__/
+build_env/
+test_env/

--- a/python-wrapper/PYPI_RELEASE_STRATEGY.md
+++ b/python-wrapper/PYPI_RELEASE_STRATEGY.md
@@ -1,0 +1,136 @@
+# PyPI Release Strategy for Cerebrium 2.0
+
+## ⚠️ IMPORTANT: Do NOT release to PyPI until ready for public announcement
+
+### Why We Need to Be Careful
+
+1. **Auto-updates**: Users who run `pip install --upgrade cerebrium` will automatically get v2.0.0
+2. **Breaking changes**: v2.0.0 may have different commands, configs, or behaviors
+3. **No rollback**: Once published to PyPI, we can't remove or hide versions (only yank in emergencies)
+4. **User surprise**: Users expect stability from pip packages
+
+## Release Strategy Options
+
+### Option 1: Beta Channel (Recommended)
+1. **Pre-release versions**: Publish as `2.0.0b1`, `2.0.0b2`, etc.
+   - These won't auto-install with `pip install cerebrium`
+   - Users must explicitly request: `pip install cerebrium==2.0.0b1`
+2. **Testing period**: Let early adopters test
+3. **Final release**: When ready, publish `2.0.0`
+
+### Option 2: Separate Package Name
+1. Create `cerebrium-v2` or `cerebrium-beta` package
+2. Early adopters use: `pip install cerebrium-v2`
+3. When ready, update main `cerebrium` package
+
+### Option 3: Hold Until Ready (Simplest)
+1. **Don't publish to PyPI** until v2.0.0 is fully ready
+2. Early adopters use GitHub releases or direct downloads
+3. Publish all at once when announcing
+
+## Pre-Release Checklist
+
+Before publishing v2.0.0 to PyPI:
+
+- [ ] All v2.0 features are stable
+- [ ] Migration guide from v1.x to v2.0 is ready
+- [ ] Documentation is updated at docs.cerebrium.ai
+- [ ] Announcement blog post/email is prepared
+- [ ] Support team is briefed on changes
+- [ ] Rollback plan exists (if critical issues found)
+
+## Testing Before Release
+
+### 1. Test on Test PyPI First
+```bash
+# Upload to Test PyPI
+twine upload --repository testpypi dist/*
+
+# Install from Test PyPI
+pip install --index-url https://test.pypi.org/simple/ cerebrium
+```
+
+### 2. Beta Testing with Pre-release
+```bash
+# In setup.py, set version to "2.0.0b1"
+VERSION = "2.0.0b1"
+
+# Upload to real PyPI (but as beta)
+twine upload dist/*
+
+# Beta testers install with:
+pip install cerebrium==2.0.0b1
+```
+
+### 3. Version Pinning Recommendation
+Advise current users to pin their version before v2.0 release:
+```bash
+# In requirements.txt or pip install
+cerebrium<2.0.0
+```
+
+## GitHub Actions Setup (When Ready)
+
+The workflow is already created but needs tokens:
+
+1. **Test PyPI Token** (for testing):
+   - Go to https://test.pypi.org/manage/account/token/
+   - Create token with scope "Entire account"
+   - Add as GitHub secret: `TEST_PYPI_API_TOKEN`
+
+2. **Production PyPI Token** (DO NOT ADD YET):
+   - Go to https://pypi.org/manage/account/token/
+   - Create token with scope "Project: cerebrium"
+   - Add as GitHub secret: `PYPI_API_TOKEN`
+   - ⚠️ **Only add this when ready to release!**
+
+## Emergency Rollback
+
+If something goes wrong after PyPI release:
+
+1. **Yank the version** (marks as broken):
+```bash
+# This prevents NEW installations but doesn't affect existing
+twine yank cerebrium==2.0.0
+```
+
+2. **Publish a patch**:
+```bash
+# Quickly release 2.0.1 with fixes
+VERSION="2.0.1"
+python -m build
+twine upload dist/*
+```
+
+## Recommended Timeline
+
+1. **Now - 2 weeks**: Internal testing, GitHub releases only
+2. **Week 3**: Publish beta to PyPI (`2.0.0b1`)
+3. **Week 4-5**: Gather feedback, fix issues
+4. **Week 6**: Final release with announcement
+
+## Commands When Ready
+
+```bash
+# Final release process (ONLY when ready):
+cd python-wrapper
+
+# Update version in setup.py and pyproject.toml to "2.0.0"
+
+# Build
+python -m build
+
+# Final check
+twine check dist/*
+
+# Upload to PyPI (THIS IS THE POINT OF NO RETURN)
+twine upload dist/*
+```
+
+## Remember
+
+- **APT/Homebrew users**: Already controlled, they choose when to update
+- **Direct download users**: Also controlled via GitHub releases  
+- **pip users**: Will auto-update - this is why we wait!
+
+The PyPI release should be the LAST step in the v2.0 rollout, done only when you're ready for all pip users to migrate.

--- a/python-wrapper/README.md
+++ b/python-wrapper/README.md
@@ -1,6 +1,6 @@
 # Cerebrium CLI
 
-Python wrapper for the Cerebrium CLI (Go-based).
+Official Python package for the Cerebrium CLI - deploy and manage AI applications with ease.
 
 ## Installation
 
@@ -8,44 +8,46 @@ Python wrapper for the Cerebrium CLI (Go-based).
 pip install cerebrium
 ```
 
-## Usage
+This will download and install the appropriate Cerebrium CLI binary for your platform.
 
-After installation, use the `cerebrium` command:
+## Quick Start
 
 ```bash
+# Login to Cerebrium
 cerebrium login
+
+# Initialize a new project
+cerebrium init my-app
+
+# Deploy your application
 cerebrium deploy
-cerebrium apps list
-cerebrium apps get <app-id>
 ```
 
-## What's Inside
+## About
 
-This package downloads and manages the Go-based Cerebrium CLI binary. When you run `pip install cerebrium`, it:
+This Python package is a wrapper that downloads and manages the Cerebrium Go CLI binary. When you install this package, it will:
 
-1. Downloads the appropriate binary for your platform (macOS, Linux, or Windows)
-2. Installs it to `~/.cerebrium/bin/`
-3. Provides a `cerebrium` command that executes the binary
+1. Detect your operating system and architecture
+2. Download the appropriate pre-compiled binary from GitHub releases
+3. Verify checksums for security
+4. Install it to `~/.cerebrium/bin/`
+5. Make it available as the `cerebrium` command
 
-## Manual Installation
+## Supported Platforms
 
-If you prefer to install the Go binary directly:
-
-```bash
-# macOS (Homebrew)
-brew install cerebriumai/tap/cerebrium
-
-# Linux/macOS (direct download)
-curl -fsSL https://github.com/CerebriumAI/cerebrium/releases/latest/download/install.sh | sh
-
-# Or download from releases
-# https://github.com/CerebriumAI/cerebrium/releases
-```
+- **macOS**: Intel (x86_64) and Apple Silicon (arm64)
+- **Linux**: x86_64 and arm64
+- **Windows**: x86_64
 
 ## Documentation
 
-Visit [docs.cerebrium.ai](https://docs.cerebrium.ai) for full documentation.
+For full documentation, visit [docs.cerebrium.ai](https://docs.cerebrium.ai)
+
+## Support
+
+- GitHub Issues: [github.com/CerebriumAI/cerebrium/issues](https://github.com/CerebriumAI/cerebrium/issues)
+- Email: support@cerebrium.ai
 
 ## License
 
-AGPL-3.0
+MIT License - see [LICENSE](https://github.com/CerebriumAI/cerebrium/blob/main/LICENSE) for details.

--- a/python-wrapper/pyproject.toml
+++ b/python-wrapper/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cerebrium"
+version = "2.0.0"
+description = "CLI for deploying and managing Cerebrium apps"
+readme = "README.md"
+authors = [
+    {name = "Cerebrium AI", email = "support@cerebrium.ai"}
+]
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Systems Administration",
+]
+requires-python = ">=3.8"
+keywords = ["cerebrium", "cli", "deployment", "ai", "ml", "machine-learning"]
+
+[project.urls]
+Documentation = "https://docs.cerebrium.ai/"
+Repository = "https://github.com/CerebriumAI/cerebrium"
+Issues = "https://github.com/CerebriumAI/cerebrium/issues"
+Changelog = "https://github.com/CerebriumAI/cerebrium/releases"
+
+[project.scripts]
+cerebrium = "cerebrium_cli:main"
+
+[tool.setuptools]
+py-modules = ["cerebrium_cli"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["cerebrium_cli*"]

--- a/python-wrapper/test_local.sh
+++ b/python-wrapper/test_local.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Test the Python package locally before publishing
+
+set -e
+
+echo "=== Testing Cerebrium Python Package Locally ==="
+
+# Clean previous builds
+rm -rf dist/ build/ *.egg-info
+
+# Build the package
+echo "Building package..."
+python -m build
+
+# Create a test virtual environment
+echo "Creating test environment..."
+python -m venv test_env
+source test_env/bin/activate
+
+# Install the package from the local wheel
+echo "Installing package..."
+pip install dist/*.whl
+
+# Test that the command works
+echo "Testing cerebrium command..."
+cerebrium --version || echo "Note: --version flag might not work until binary is downloaded"
+
+# Show where it installed
+echo "Package installed at:"
+which cerebrium
+pip show cerebrium
+
+# Clean up
+deactivate
+rm -rf test_env
+
+echo "=== Local testing complete ==="
+echo ""
+echo "To publish to Test PyPI:"
+echo "  1. Get Test PyPI token from https://test.pypi.org/manage/account/token/"
+echo "  2. Run: twine upload --repository testpypi dist/*"
+echo ""
+echo "To publish to PyPI:"
+echo "  1. Get PyPI token from https://pypi.org/manage/account/token/"
+echo "  2. Run: twine upload dist/*"


### PR DESCRIPTION
- Add pyproject.toml for modern Python packaging
- Create GitHub Actions workflow for PyPI publishing (requires secrets to be set)
- Add comprehensive PyPI release strategy documentation
- Update Python wrapper README with installation instructions
- Add test script for local package validation
- Add .gitignore for Python build artifacts

IMPORTANT: This does NOT auto-publish to PyPI. Publishing requires:
1. Setting PYPI_API_TOKEN secret in GitHub (not set)
2. Manually triggering the workflow or creating a release
3. Following the strategy in PYPI_RELEASE_STRATEGY.md

This allows controlled rollout to avoid surprising existing pip users with v2.0.0

## Testing

Tested locally:
- Package builds successfully
- Installation works: `pip install cerebrium-2.0.0-py3-none-any.whl`
- Binary downloads and installs correctly
- Checksum verification works
- `cerebrium` command executes properly
- Shows correct version: `cerebrium 2.0.0`

## Next Steps

When ready to release v2.0.0 to pip users:
1. Create PyPI account and API tokens
2. Add `TEST_PYPI_API_TOKEN` secret for testing
3. Test with beta release (e.g., `2.0.0b1`)
4. When ready for full release, add `PYPI_API_TOKEN` secret
5. Create GitHub release or manually trigger workflow
