### PR TITLE
refactor: simplify list commands and add deploy scroll fix

### DIFF
--- a/internal/commands/apps/list.go
+++ b/internal/commands/apps/list.go
@@ -1,14 +1,11 @@
 package apps
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cerebriumai/cerebrium/internal/api"
 	"github.com/cerebriumai/cerebrium/internal/ui"
-	"github.com/cerebriumai/cerebrium/internal/ui/commands/apps"
 	"github.com/cerebriumai/cerebrium/pkg/config"
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 
@@ -19,8 +16,7 @@ func newListCmd() *cobra.Command {
 		Long: `List all apps under your current context.
 
 Example:
-  cerebrium apps list
-  cerebrium apps list --no-color  # Disable animations and colors`,
+  cerebrium apps list`,
 		RunE: runList,
 	}
 
@@ -28,76 +24,52 @@ Example:
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	// Suppress Cobra's default error handling - we control it in main.go
 	cmd.SilenceUsage = true
-	cmd.SilenceErrors = true
 
-	// Get display options from context (loaded once in root command)
-	displayOpts, err := ui.GetDisplayConfigFromContext(cmd)
-	if err != nil {
-		return fmt.Errorf("failed to get display options: %w", err)
-	}
-
-	// Get config from context (loaded once in root command)
+	// Get config from context
 	cfg, err := config.GetConfigFromContext(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to get config: %w", err)
+		return ui.NewValidationError(fmt.Errorf("failed to get config: %w", err))
 	}
 
 	// Get current project
 	projectID, err := cfg.GetCurrentProject()
 	if err != nil {
-		return fmt.Errorf("failed to get current project: %w", err)
+		return ui.NewValidationError(fmt.Errorf("failed to get current project: %w", err))
 	}
 
 	// Create API client
 	client, err := api.NewClient(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
+		return ui.NewValidationError(fmt.Errorf("failed to create API client: %w", err))
 	}
 
-	// Create Bubbletea model with display options
-	model := apps.NewListView(cmd.Context(), apps.ListConfig{
-		DisplayConfig: displayOpts,
-		Client:        client,
-		ProjectID:     projectID,
-	})
+	// Show spinner while fetching
+	spinner := ui.NewSimpleSpinner("Loading apps...")
+	spinner.Start()
 
-	// Configure Bubbletea based on display options
-	var programOpts []tea.ProgramOption
-
-	if !displayOpts.IsInteractive {
-		// Non-interactive mode: disable renderer and input
-		programOpts = append(programOpts,
-			tea.WithoutRenderer(),
-			tea.WithInput(nil),
-		)
-	}
-
-	// Run Bubbletea program (it will fetch data, show spinner/table, then exit)
-	p := tea.NewProgram(model, programOpts...)
-	doneCh := ui.SetupSignalHandling(p, 0)
-	defer close(doneCh)
-
-	finalModel, err := p.Run()
+	// Fetch apps
+	apps, err := client.GetApps(cmd.Context(), projectID)
+	spinner.Stop()
 	if err != nil {
-		return fmt.Errorf("ui error: %w", err)
+		return ui.NewAPIError(err)
 	}
 
-	// Extract model
-	m, ok := finalModel.(*apps.ListView)
-	if !ok {
-		return fmt.Errorf("unexpected model type")
+	// Print results
+	if len(apps) == 0 {
+		fmt.Printf("No apps found for project %s\n", projectID)
+		return nil
 	}
 
-	// In non-TTY mode, output has already been printed directly
-	// No need to print View() output since it returns empty string
-
-	// Check if there were any errors during execution
-	// Handle UIError - check if it should be silent
-	var uiErr *ui.UIError
-	if errors.As(m.Error(), &uiErr) && !uiErr.SilentExit {
-		return uiErr
+	// Print table header and rows
+	fmt.Printf("%-50s %-10s %-20s %-20s\n", "ID", "STATUS", "CREATED", "UPDATED")
+	for _, app := range apps {
+		fmt.Printf("%-50s %-10s %-20s %-20s\n",
+			app.ID,
+			app.Status,
+			app.CreatedAt.Format("2006-01-02 15:04:05"),
+			app.UpdatedAt.Format("2006-01-02 15:04:05"),
+		)
 	}
 
 	return nil

--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -159,6 +159,12 @@ func runDeploy(cmd *cobra.Command, opts deployOptions, disableConfirmation bool)
 		)
 	}
 
+	// Print a newline to preserve the command line in terminal history
+	// This prevents Bubbletea's renderer from overwriting the "cerebrium deploy" line
+	if displayOpts.IsInteractive {
+		fmt.Println()
+	}
+
 	// Run Bubbletea program (it handles its own cleanup)
 	p := tea.NewProgram(model, programOpts...)
 

--- a/internal/commands/projects/list.go
+++ b/internal/commands/projects/list.go
@@ -1,14 +1,11 @@
 package projects
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cerebriumai/cerebrium/internal/api"
 	"github.com/cerebriumai/cerebrium/internal/ui"
-	"github.com/cerebriumai/cerebrium/internal/ui/commands/projects"
 	"github.com/cerebriumai/cerebrium/pkg/config"
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 
@@ -19,8 +16,7 @@ func newListCmd() *cobra.Command {
 		Long: `List all projects under your account.
 
 Example:
-  cerebrium projects list
-  cerebrium projects list --no-color  # Disable animations and colors`,
+  cerebrium projects list`,
 		RunE: runList,
 	}
 
@@ -28,70 +24,45 @@ Example:
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	// Suppress Cobra's default error handling - we control it in main.go
 	cmd.SilenceUsage = true
-	cmd.SilenceErrors = true
 
-	// Get display options from context (loaded once in root command)
-	displayOpts, err := ui.GetDisplayConfigFromContext(cmd)
-	if err != nil {
-		return fmt.Errorf("failed to get display options: %w", err)
-	}
-
-	// Get config from context (loaded once in root command)
+	// Get config from context
 	cfg, err := config.GetConfigFromContext(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to get config: %w", err)
+		return ui.NewValidationError(fmt.Errorf("failed to get config: %w", err))
 	}
 
 	// Create API client
 	client, err := api.NewClient(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
+		return ui.NewValidationError(fmt.Errorf("failed to create API client: %w", err))
 	}
 
-	// Create Bubbletea model with display options
-	model := projects.NewListView(cmd.Context(), projects.ListConfig{
-		DisplayConfig: displayOpts,
-		Client:        client,
-	})
+	// Show spinner while fetching
+	spinner := ui.NewSimpleSpinner("Loading projects...")
+	spinner.Start()
 
-	// Configure Bubbletea based on display options
-	var programOpts []tea.ProgramOption
-
-	if !displayOpts.IsInteractive {
-		// Non-interactive mode: disable renderer and input
-		programOpts = append(programOpts,
-			tea.WithoutRenderer(),
-			tea.WithInput(nil),
-		)
-	}
-
-	// Run Bubbletea program (it will fetch data, show spinner/table, then exit)
-	p := tea.NewProgram(model, programOpts...)
-	doneCh := ui.SetupSignalHandling(p, 0) // No need for special cleanup
-	defer close(doneCh)
-
-	finalModel, err := p.Run()
+	// Fetch projects
+	projects, err := client.GetProjects(cmd.Context())
+	spinner.Stop()
 	if err != nil {
-		return fmt.Errorf("ui error: %w", err)
+		return ui.NewAPIError(err)
 	}
 
-	// Extract model
-	m, ok := finalModel.(*projects.ListView)
-	if !ok {
-		return fmt.Errorf("unexpected model type")
+	// Print results
+	if len(projects) == 0 {
+		fmt.Println("No projects found")
+		return nil
 	}
 
-	// In non-TTY mode, output has already been printed directly
-	// No need to print View() output since it returns empty string
-
-	// Check if there were any errors during execution
-	// Handle UIError - check if it should be silent
-	var uiErr *ui.UIError
-	if errors.As(m.Error(), &uiErr) && !uiErr.SilentExit {
-		return uiErr
+	// Print table header and rows
+	fmt.Printf("%-50s %-50s\n", "ID", "NAME")
+	for _, project := range projects {
+		fmt.Printf("%-50s %-50s\n", project.ID, project.Name)
 	}
+
+	fmt.Println()
+	fmt.Println("You can set your current project by running `cerebrium projects set {project_id}`")
 
 	return nil
 }

--- a/internal/ui/commands/runs/list.go
+++ b/internal/ui/commands/runs/list.go
@@ -3,16 +3,14 @@ package runs
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sort"
 	"strings"
 
-	"github.com/cerebriumai/cerebrium/internal/ui"
-	"github.com/charmbracelet/lipgloss"
-
 	"github.com/cerebriumai/cerebrium/internal/api"
+	"github.com/cerebriumai/cerebrium/internal/ui"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // ListConfig configures the runs list view
@@ -144,98 +142,16 @@ func (m *ListView) View() string {
 	output.WriteString(m.table.View())
 	output.WriteString("\n\n")
 
-	if ui.TableBiggerThanView(m.table) {
-		// Add navigation help (indented by one space to distinguish from regular output)
-		navHelp := " j/k scroll • J/K scroll to bottom/top • ctrl+d/ctrl+u page up/down • <esc> or q to quit"
-		output.WriteString(ui.HelpStyle.Render(navHelp))
-		output.WriteString("\n")
-	}
 	return output.String()
 }
 
 // Commands
 
 func (m *ListView) onKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.conf.SimpleOutput() {
-		return m, nil
-	}
-	slog.Debug("key pressed", "key", msg.String())
-
+	// Handle quit keys only
 	switch msg.String() {
-	case "q", "esc":
+	case "ctrl+c", "q", "esc":
 		return m, tea.Quit
-	case "J":
-		return m.scrollToBottom()
-	case "K":
-		return m.scrollToTop()
-	case "j":
-		return m.scrollDown()
-	case "k":
-		return m.scrollUp()
-	case "ctrl+d":
-		return m.pageDown()
-	case "ctrl+u":
-		return m.pageUp()
-	}
-
-	// Let table handle navigation (j/k, arrows)
-	return m.delegateToTable(msg)
-}
-
-// scrollToBottom scrolls the table to the bottom
-func (m *ListView) scrollToBottom() (tea.Model, tea.Cmd) {
-	if !m.loading && len(m.table.Rows()) > 0 {
-		m.table.GotoBottom()
-	}
-	return m, nil
-}
-
-// scrollToTop scrolls the table to the top
-func (m *ListView) scrollToTop() (tea.Model, tea.Cmd) {
-	if !m.loading && len(m.table.Rows()) > 0 {
-		m.table.GotoTop()
-	}
-	return m, nil
-}
-
-// scrollDown scrolls the table to the bottom
-func (m *ListView) scrollDown() (tea.Model, tea.Cmd) {
-	if !m.loading && len(m.table.Rows()) > 0 {
-		m.table.MoveDown(1)
-	}
-	return m, nil
-}
-
-// scrollUp scrolls the table to the top
-func (m *ListView) scrollUp() (tea.Model, tea.Cmd) {
-	if !m.loading && len(m.table.Rows()) > 0 {
-		m.table.MoveUp(1)
-	}
-	return m, nil
-}
-
-// pageDown scrolls the table to the bottom
-func (m *ListView) pageDown() (tea.Model, tea.Cmd) {
-	if !m.loading && len(m.table.Rows()) > 0 {
-		m.table.MoveDown(10)
-	}
-	return m, nil
-}
-
-// pageUp scrolls the table to the top
-func (m *ListView) pageUp() (tea.Model, tea.Cmd) {
-	if !m.loading && len(m.table.Rows()) > 0 {
-		m.table.MoveUp(10)
-	}
-	return m, nil
-}
-
-// delegateToTable passes navigation keys to the table
-func (m *ListView) delegateToTable(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if !m.loading && len(m.table.Rows()) > 0 {
-		var cmd tea.Cmd
-		m.table, cmd = m.table.Update(msg)
-		return m, cmd
 	}
 	return m, nil
 }
@@ -257,7 +173,9 @@ func (m *ListView) onLoaded(runs []api.Run) (tea.Model, tea.Cmd) {
 			// Print simple table format
 			fmt.Print(m.formatRunsTable())
 		}
+		return m, tea.Quit
 	}
+
 	// Interactive mode: create fancy table with colors and styling
 	var rows []table.Row
 	for _, run := range m.runs {
@@ -269,14 +187,10 @@ func (m *ListView) onLoaded(runs []api.Run) (tea.Model, tea.Cmd) {
 			m.formatAsyncStatus(run.Async),
 		})
 	}
-	// Create styled table
-	m.table = newTable(rows)
 
-	// Auto-quit if table fits on screen (no scrolling needed)
-	if !ui.TableBiggerThanView(m.table) {
-		return m, tea.Quit
-	}
-	return m, nil
+	// Create styled table and quit (non-interactive)
+	m.table = newTable(rows)
+	return m, tea.Quit
 }
 
 // formatRunsTable formats runs for non-TTY output
@@ -416,7 +330,7 @@ func newTable(rows []table.Row) table.Model {
 		{Title: "Async", Width: widths[4] + padding},
 	}
 
-	// Style the table (matching app list styling)
+	// Style the table (non-interactive, no selection highlighting)
 	s := table.DefaultStyles()
 	s.Header = s.Header.
 		BorderStyle(lipgloss.NormalBorder()).
@@ -424,13 +338,17 @@ func newTable(rows []table.Row) table.Model {
 		BorderBottom(true).
 		Bold(true).
 		Padding(0, 1)
-	s.Selected = s.Selected.Bold(true)
+	// Remove selection highlighting for non-interactive mode
+	s.Selected = s.Selected.
+		Foreground(lipgloss.NoColor{}).
+		Background(lipgloss.NoColor{}).
+		Bold(false)
 
-	// Create table with styling
+	// Create table with styling - show all rows, not focused
 	t := table.New(
 		table.WithColumns(columns),
 		table.WithRows(rows),
-		table.WithHeight(min(len(rows)+1, ui.MAX_TABLE_HEIGHT)), // Include header
+		table.WithHeight(len(rows)+1), // Show all rows
 		table.WithFocused(false),
 	)
 	t.SetStyles(s)

--- a/internal/ui/commands/runs/testdata/runs_list_many_runs.golden
+++ b/internal/ui/commands/runs/testdata/runs_list_many_runs.golden
@@ -16,5 +16,14 @@ Runs for test-app
  run-14          predict                success          2025-01-01 12:13:00          No            
  run-13          predict                success          2025-01-01 12:12:00          Yes           
  run-12          predict                success          2025-01-01 12:11:00          No            
-
-  j/k scroll • J/K scroll to bottom/top • ctrl+d/ctrl+u page up/down • <esc> or q to quit
+ run-11          predict                success          2025-01-01 12:10:00          Yes           
+ run-10          predict                success          2025-01-01 12:09:00          No            
+ run-09          predict                success          2025-01-01 12:08:00          Yes           
+ run-08          predict                success          2025-01-01 12:07:00          No            
+ run-07          predict                success          2025-01-01 12:06:00          Yes           
+ run-06          predict                success          2025-01-01 12:05:00          No            
+ run-05          predict                success          2025-01-01 12:04:00          Yes           
+ run-04          predict                success          2025-01-01 12:03:00          No            
+ run-03          predict                success          2025-01-01 12:02:00          Yes           
+ run-02          predict                success          2025-01-01 12:01:00          No            
+ run-01          predict                success          2025-01-01 12:00:00          Yes

--- a/internal/ui/simplespinner.go
+++ b/internal/ui/simplespinner.go
@@ -1,0 +1,65 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/mattn/go-isatty"
+)
+
+// SimpleSpinner provides a non-Bubbletea spinner for simple CLI output
+type SimpleSpinner struct {
+	message string
+	frames  []string
+	stop    chan struct{}
+	done    chan struct{}
+	mu      sync.Mutex
+}
+
+// NewSimpleSpinner creates a new simple spinner with a message
+func NewSimpleSpinner(message string) *SimpleSpinner {
+	return &SimpleSpinner{
+		message: message,
+		frames:  []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+// Start begins the spinner animation
+func (s *SimpleSpinner) Start() {
+	// Only show spinner if stdout is a TTY
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		close(s.done)
+		return
+	}
+
+	go func() {
+		defer close(s.done)
+		i := 0
+		ticker := time.NewTicker(80 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-s.stop:
+				// Clear the spinner line
+				fmt.Print("\r\033[K")
+				return
+			case <-ticker.C:
+				s.mu.Lock()
+				fmt.Printf("\r%s %s", s.frames[i%len(s.frames)], s.message)
+				s.mu.Unlock()
+				i++
+			}
+		}
+	}()
+}
+
+// Stop stops the spinner animation
+func (s *SimpleSpinner) Stop() {
+	close(s.stop)
+	<-s.done
+}


### PR DESCRIPTION
- Replace Bubbletea-based list commands with simple fmt.Printf tables
- Add SimpleSpinner utility for lightweight loading indicators
- List commands (projects, apps, runs, ls) now show spinner while loading
- Add newline before deploy UI to preserve command line in terminal history
- Remove interactive table navigation (will be re-added later with actions)