### PR TITLE
fix: Include subdirectories when directory pattern ends with /

### DIFF
--- a/internal/files/include.go
+++ b/internal/files/include.go
@@ -85,9 +85,10 @@ func normalizePatterns(patterns []string) []string {
 		// Remove leading "./"
 		p = strings.TrimPrefix(p, "./")
 
-		// If pattern ends with /, append * for directory matching
+		// If pattern ends with /, append ** for recursive directory matching
+		// e.g., "assets/" becomes "assets/**" to include all files in subdirectories
 		if strings.HasSuffix(p, "/") {
-			p = p + "*"
+			p = p + "**"
 		}
 
 		normalized = append(normalized, p)

--- a/internal/files/include_test.go
+++ b/internal/files/include_test.go
@@ -1,9 +1,11 @@
 package files
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_matchesGlob(t *testing.T) {
@@ -88,4 +90,158 @@ func Test_matchesGlob(t *testing.T) {
 				"matchesGlob(%q, %q) = %v, want %v", tc.path, tc.pattern, result, tc.expected)
 		})
 	}
+}
+
+func Test_normalizePatterns(t *testing.T) {
+	tcs := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "directory with trailing slash becomes recursive",
+			input:    []string{"assets/"},
+			expected: []string{"assets/**"},
+		},
+		{
+			name:     "multiple directories",
+			input:    []string{"src/", "models/", "assets/"},
+			expected: []string{"src/**", "models/**", "assets/**"},
+		},
+		{
+			name:     "file patterns unchanged",
+			input:    []string{"main.py", "cerebrium.toml"},
+			expected: []string{"main.py", "cerebrium.toml"},
+		},
+		{
+			name:     "mixed files and directories",
+			input:    []string{"src/", "main.py", "assets/"},
+			expected: []string{"src/**", "main.py", "assets/**"},
+		},
+		{
+			name:     "removes leading ./",
+			input:    []string{"./src/", "./main.py"},
+			expected: []string{"src/**", "main.py"},
+		},
+		{
+			name:     "glob patterns unchanged",
+			input:    []string{"**/*.py", "*.txt"},
+			expected: []string{"**/*.py", "*.txt"},
+		},
+		{
+			name:     "empty patterns filtered",
+			input:    []string{"src/", "", "  ", "main.py"},
+			expected: []string{"src/**", "main.py"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := normalizePatterns(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestDetermineIncludes_DirectoryWithSubdirectories(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	
+	// Change to temp directory for the test
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalDir) }()
+
+	// Create directory structure like a real project
+	dirs := []string{
+		"assets/shaders/nested",
+		"src/utils",
+		"models/v1",
+	}
+	for _, dir := range dirs {
+		err := os.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+	}
+
+	// Create files
+	files := []string{
+		"main.py",
+		"cerebrium.toml",
+		"assets/image.jpg",
+		"assets/shaders/vertex.glsl",
+		"assets/shaders/fragment.glsl",
+		"assets/shaders/nested/compute.glsl",
+		"src/main.py",
+		"src/utils/helper.py",
+		"models/model.pt",
+		"models/v1/weights.bin",
+	}
+	for _, file := range files {
+		err := os.WriteFile(file, []byte("test"), 0644)
+		require.NoError(t, err)
+	}
+
+	// Test that directory patterns include subdirectories
+	include := []string{"assets/", "src/", "models/", "main.py", "cerebrium.toml"}
+	exclude := []string{}
+
+	result, err := DetermineIncludes(include, exclude)
+	require.NoError(t, err)
+
+	// All files should be included
+	expected := []string{
+		"assets/image.jpg",
+		"assets/shaders/fragment.glsl",
+		"assets/shaders/nested/compute.glsl",
+		"assets/shaders/vertex.glsl",
+		"cerebrium.toml",
+		"main.py",
+		"models/model.pt",
+		"models/v1/weights.bin",
+		"src/main.py",
+		"src/utils/helper.py",
+	}
+
+	assert.ElementsMatch(t, expected, result, 
+		"Directory patterns should include all files in subdirectories")
+}
+
+func TestDetermineIncludes_ExcludeSubdirectory(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+	
+	// Change to temp directory for the test
+	originalDir, err := os.Getwd()
+	require.NoError(t, err)
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalDir) }()
+
+	// Create directory structure
+	err = os.MkdirAll("assets/shaders", 0755)
+	require.NoError(t, err)
+
+	// Create files
+	files := []string{
+		"assets/image.jpg",
+		"assets/shaders/vertex.glsl",
+	}
+	for _, file := range files {
+		err := os.WriteFile(file, []byte("test"), 0644)
+		require.NoError(t, err)
+	}
+
+	// Include assets but exclude shaders subdirectory
+	include := []string{"assets/"}
+	exclude := []string{"assets/shaders/"}
+
+	result, err := DetermineIncludes(include, exclude)
+	require.NoError(t, err)
+
+	// Only the image should be included, not the shader
+	expected := []string{"assets/image.jpg"}
+	assert.ElementsMatch(t, expected, result,
+		"Exclude patterns should work on subdirectories")
 }


### PR DESCRIPTION
When users specify a directory in their include list (e.g., 'assets/'), the CLI was only including files directly in that directory, not files in subdirectories. This caused build failures when Dockerfiles referenced files in subdirectories like 'assets/shaders/'.

The fix changes the pattern normalization from appending '*' to '**':
- Before: 'assets/' -> 'assets/*' (only direct children)
- After: 'assets/' -> 'assets/**' (all descendants recursively)

This matches user expectations that 'assets/' should include everything under the assets directory, similar to how 'cp -r assets/' works.

Added comprehensive tests for:
- normalizePatterns function behavior
- DetermineIncludes with nested subdirectories
- Exclude patterns on subdirectories