### PR TITLE
fix: display API error messages during deploy

### DIFF
--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -484,7 +484,7 @@ func (m *DeployView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case *ui.UIError:
 		// Structured error from async operations
 		m.ctxCancel()         // Stop all subprocesses
-		msg.SilentExit = true // Will be shown in View()
+		msg.SilentExit = true // Will be shown below
 		m.err = msg
 		m.state = StateDeployError
 
@@ -507,10 +507,16 @@ func (m *DeployView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if m.conf.SimpleOutput() {
-			fmt.Printf("Error: %s\n", msg.Error())
+			fmt.Printf("✗ %s\n", msg.Error())
+			return m, tea.Quit
 		}
 
-		return m, tea.Quit
+		// Print error message to scrollback in interactive mode
+		return m, tea.Sequence(
+			tea.Println(""),
+			tea.Println(ui.ErrorStyle.Render(fmt.Sprintf("✗ %s", msg.Error()))),
+			tea.Quit,
+		)
 
 	default:
 		// Update spinner only in interactive mode


### PR DESCRIPTION
Previously, API error messages (e.g., 'requested max replicas exceeds plan limit') were silently swallowed during deploy. The error handler set SilentExit=true expecting View() to display the error, but View() returned empty for error states.

This fix ensures errors are properly displayed:
- Interactive mode: Uses tea.Sequence to print error to scrollback before quit
- SimpleOutput mode: Prints error with checkmark and explicit return

Fixes issue where deploy would silently fail after 'Zipped files' step.