### PR TITLE
fix: make ./* and * patterns include all files recursively

### DIFF
--- a/internal/files/include.go
+++ b/internal/files/include.go
@@ -82,13 +82,18 @@ func normalizePatterns(patterns []string) []string {
 		// Convert to forward slashes for consistency
 		p = filepath.ToSlash(p)
 
-		// Remove leading "./"
-		p = strings.TrimPrefix(p, "./")
+		// Handle "./*" and "*" as "include everything recursively"
+		if p == "./*" || p == "*" {
+			p = "**/*"
+		} else {
+			// Remove leading "./"
+			p = strings.TrimPrefix(p, "./")
 
-		// If pattern ends with /, append ** for recursive directory matching
-		// e.g., "assets/" becomes "assets/**" to include all files in subdirectories
-		if strings.HasSuffix(p, "/") {
-			p = p + "**"
+			// If pattern ends with /, append ** for recursive directory matching
+			// e.g., "assets/" becomes "assets/**" to include all files in subdirectories
+			if strings.HasSuffix(p, "/") {
+				p = p + "**"
+			}
 		}
 
 		normalized = append(normalized, p)


### PR DESCRIPTION
Previously, './*' normalized to '*' which only matched root-level files. Now './*' and '*' both normalize to '**/*' to match all files recursively, aligning with Python CLI behavior.

This fixes the common pattern:
  include = ['./*']

Which users expect to include all files in all subdirectories.