### PR TITLE
feat: add model_name and language support for Rime partner service

### DIFF
--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -75,8 +75,10 @@ type CustomRuntimeConfig struct {
 
 // PartnerServiceConfig represents partner service configurations
 type PartnerServiceConfig struct {
-	Name string `mapstructure:"name" toml:"name,omitempty"`
-	Port *int   `mapstructure:"port" toml:"port,omitempty"`
+	Name      string  `mapstructure:"name" toml:"name,omitempty"`
+	Port      *int    `mapstructure:"port" toml:"port,omitempty"`
+	ModelName *string `mapstructure:"model_name" toml:"model_name,omitempty"`
+	Language  *string `mapstructure:"language" toml:"language,omitempty"`
 }
 
 // ToPayload converts the project config to an API payload
@@ -168,6 +170,12 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		payload["dockerfilePath"] = pc.CustomRuntime.DockerfilePath
 		payload["partnerService"] = pc.PartnerService.Name
 		payload["runtime"] = pc.PartnerService.Name
+		if pc.PartnerService.ModelName != nil {
+			payload["modelName"] = *pc.PartnerService.ModelName
+		}
+		if pc.PartnerService.Language != nil {
+			payload["language"] = *pc.PartnerService.Language
+		}
 	} else if pc.CustomRuntime != nil {
 		// Custom runtime only
 		payload["entrypoint"] = pc.CustomRuntime.Entrypoint
@@ -182,6 +190,12 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		payload["runtime"] = pc.PartnerService.Name
 		if pc.PartnerService.Port != nil {
 			payload["port"] = *pc.PartnerService.Port
+		}
+		if pc.PartnerService.ModelName != nil {
+			payload["modelName"] = *pc.PartnerService.ModelName
+		}
+		if pc.PartnerService.Language != nil {
+			payload["language"] = *pc.PartnerService.Language
 		}
 	} else {
 		// Default cortex runtime

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -96,6 +96,18 @@ func Load(configPath string) (*ProjectConfig, error) {
 				partnerConfig.Port = &port
 			}
 
+			// Check for model_name (e.g., "arcana", "mist")
+			if v.IsSet(key + ".model_name") {
+				modelName := v.GetString(key + ".model_name")
+				partnerConfig.ModelName = &modelName
+			}
+
+			// Check for language (e.g., "en", "es")
+			if v.IsSet(key + ".language") {
+				language := v.GetString(key + ".language")
+				partnerConfig.Language = &language
+			}
+
 			config.PartnerService = partnerConfig
 			break // Only one partner service at a time
 		}


### PR DESCRIPTION
- Add ModelName and Language fields to PartnerServiceConfig struct
- Parse model_name and language from [cerebrium.runtime.rime] config section
- Include modelName and language in API payload for partner service deployments

This enables deploying Rime Arcana TTS with configuration like:

[cerebrium.runtime.rime]
port = 8001
model_name = "arcana"
language = "en"