### PR TITLE
fix: display all progress bar updates in CLI during model downloads

### DIFF
--- a/internal/ui/logging/viewer.go
+++ b/internal/ui/logging/viewer.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cerebriumai/cerebrium/internal/ui"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cerebriumai/cerebrium/internal/ui"
 )
 
 type viewerState int
@@ -46,14 +46,14 @@ type LogViewerModel struct {
 	scrollOffset  int
 	anchorBottom  bool                // Auto-scroll to show latest logs
 	printedLogIDs map[string]struct{} // Set of log IDs already printed (for AutoExpand mode)
-	headerPrinted bool                // Whether the "Build Logs" header has been printed
+	headerPrinted bool                // Whether the "Logs" header has been printed
 
 	err error
 }
 
 const (
-	// maxLogsInMemory is the hard limit for logs stored in memory
-	// When exceeded, oldest logs are evicted
+	// maxLogsInMemory is the hard limit for logs stored in memory.
+	// When exceeded, oldest logs are evicted.
 	maxLogsInMemory = 10_000
 )
 
@@ -72,7 +72,7 @@ func NewLogViewer(ctx context.Context, config LogViewerConfig) *LogViewerModel {
 		config:        config,
 		state:         viewerStateInitialising,
 		spinner:       ui.NewSpinner(),
-		logChan:       make(chan []Log, 10), // Buffered to prevent blocking provider
+		logChan:       make(chan []Log, 100), // Buffered to prevent blocking provider
 		doneChan:      make(chan error),
 		anchorBottom:  true,                      // Auto-scroll to bottom by default
 		printedLogIDs: make(map[string]struct{}), // Track printed logs by ID
@@ -111,7 +111,6 @@ func (m *LogViewerModel) Init() tea.Cmd {
 func (m *LogViewerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case logBatchReceivedMsg:
-		// Buffer logs silently (don't trigger render for every new log)
 		for _, log := range msg.logs {
 			m.logs = append(m.logs, log)
 


### PR DESCRIPTION
## Problem

When deploying large models (e.g., 250GB), the CLI was not showing progress completion for models, while the dashboard correctly displayed all intermediate progress updates (0%, 1%, 2%, etc.).

## Root Cause

Progress bar libraries (like tqdm used by HuggingFace) use two terminal control mechanisms for in-place updates:

1. Carriage return (\r) - moves cursor to start of line
2. ANSI cursor movement codes (\x1b[A) - moves cursor up to overwrite

The CLI was receiving these raw escape sequences but not processing them, causing intermediate updates to be overwritten in the terminal buffer.

## Solution

In `streaming_build_provider.go`:

1. **Strip ANSI cursor movement codes** - Remove sequences like \x1b[A (cursor up) that cause terminal overwriting

2. **Normalize carriage returns** - Convert \r to \n so each progress update becomes a separate displayable line

3. **Filter empty lines** - Skip lines that only contain process prefixes (e.g., "(EngineCore_DP0 pid=198)") with no actual content

This matches the dashboard's approach which also converts \r to \n before display.

## Changes

- `streaming_build_provider.go`: Added log normalization logic with regex patterns for ANSI codes and process prefixes
- `viewer.go`: Minor cleanup (increased log channel buffer, comment fixes)

## Testing

Verified with multiple model deployments showing full intermediate progress:
- config.json downloads (small files)
- model.safetensors downloads (multi-GB files)
- CUDA graph capturing progress

## Safety

- No memory accumulation: each log processed independently
- No state tracking: stateless processing
- Same behavior as production dashboard
- Efficient string operations on individual log messages (~1KB each)


TESTING : 

``
17:52:10.080 model.safetensors:   0%|          | 0.00/6.43G [00:00<?, ?B/s]
17:52:10.793 model.safetensors:   0%|          | 1.55M/6.43G [00:01<1:31:10, 1.18MB/s]
17:52:11.295 model.safetensors:   1%|          | 68.6M/6.43G [00:02<02:32, 41.7MB/s]  
17:52:12.252 model.safetensors:   2%|▏         | 138M/6.43G [00:02<01:28, 71.5MB/s] 
17:52:12.671 model.safetensors:   3%|▎         | 205M/6.43G [00:03<01:27, 70.8MB/s]
17:52:13.004 model.safetensors:   6%|▋         | 407M/6.43G [00:03<00:37, 161MB/s] 
17:52:13.244 model.safetensors:   7%|▋         | 474M/6.43G [00:04<00:35, 169MB/s]
17:52:13.532 model.safetensors:   8%|▊         | 541M/6.43G [00:04<00:31, 188MB/s]
17:52:14.064 model.safetensors:   9%|▉         | 608M/6.43G [00:04<00:29, 198MB/s]
17:52:14.409 model.safetensors:  11%|█         | 679M/6.43G [00:05<00:33, 174MB/s]
17:52:14.666 model.safetensors:  12%|█▏        | 746M/6.43G [00:05<00:31, 179MB/s]
17:52:14.993 model.safetensors:  13%|█▎        | 813M/6.43G [00:05<00:28, 197MB/s]
17:52:15.283 model.safetensors:  14%|█▎        | 880M/6.43G [00:06<00:27, 199MB/s]
17:52:15.561 model.safetensors:  16%|█▌        | 1.01G/6.43G [00:06<00:20, 268MB/s]
17:52:15.837 model.safetensors:  17%|█▋        | 1.08G/6.43G [00:06<00:20, 261MB/s]
17:52:16.091 model.safetensors:  18%|█▊        | 1.15G/6.43G [00:07<00:20, 256MB/s]
17:52:16.382 model.safetensors:  19%|█▉        | 1.22G/6.43G [00:07<00:20, 258MB/s]
17:52:16.764 model.safetensors:  20%|█▉        | 1.28G/6.43G [00:07<00:20, 250MB/s]
17:52:17.141 model.safetensors:  21%|██        | 1.35G/6.43G [00:07<00:22, 223MB/s]
17:52:17.415 model.safetensors:  22%|██▏       | 1.42G/6.43G [00:08<00:24, 208MB/s]
17:52:18.132 model.safetensors:  23%|██▎       | 1.48G/6.43G [00:08<00:22, 217MB/s]
17:52:18.495 model.safetensors:  24%|██▍       | 1.55G/6.43G [00:09<00:31, 156MB/s]
17:52:18.797 model.safetensors:  26%|██▌       | 1.68G/6.43G [00:09<00:22, 212MB/s]
17:52:19.110 model.safetensors:  27%|██▋       | 1.75G/6.43G [00:10<00:21, 215MB/s]
17:52:19.452 model.safetensors:  28%|██▊       | 1.82G/6.43G [00:10<00:21, 214MB/s]
17:52:19.753 model.safetensors:  29%|██▉       | 1.89G/6.43G [00:10<00:21, 209MB/s]
17:52:20.090 model.safetensors:  30%|███       | 1.95G/6.43G [00:10<00:21, 213MB/s]
17:52:20.399 model.safetensors:  31%|███▏      | 2.02G/6.43G [00:11<00:21, 209MB/s]
17:52:20.713 model.safetensors:  32%|███▏      | 2.08G/6.43G [00:11<00:20, 210MB/s]
17:52:20.941 model.safetensors:  33%|███▎      | 2.15G/6.43G [00:11<00:20, 211MB/s]
17:52:21.233 model.safetensors:  35%|███▍      | 2.23G/6.43G [00:12<00:17, 236MB/s]
17:52:21.503 model.safetensors:  36%|███▌      | 2.29G/6.43G [00:12<00:17, 234MB/s]
17:52:21.887 model.safetensors:  37%|███▋      | 2.36G/6.43G [00:12<00:17, 238MB/s]
17:52:22.200 model.safetensors:  38%|███▊      | 2.43G/6.43G [00:13<00:18, 215MB/s]
17:52:22.536 model.safetensors:  39%|███▉      | 2.49G/6.43G [00:13<00:18, 215MB/s]
17:52:22.814 model.safetensors:  40%|███▉      | 2.56G/6.43G [00:13<00:18, 210MB/s]
17:52:23.132 model.safetensors:  41%|████      | 2.63G/6.43G [00:14<00:17, 218MB/s]
17:52:23.420 model.safetensors:  42%|████▏     | 2.69G/6.43G [00:14<00:17, 216MB/s]
17:52:23.771 model.safetensors:  43%|████▎     | 2.76G/6.43G [00:14<00:16, 221MB/s]
17:52:24.190 model.safetensors:  44%|████▍     | 2.83G/6.43G [00:15<00:17, 211MB/s]
17:52:24.470 model.safetensors:  45%|████▌     | 2.90G/6.43G [00:15<00:18, 193MB/s]
17:52:24.711 model.safetensors:  46%|████▌     | 2.96G/6.43G [00:15<00:16, 205MB/s]
17:52:24.988 model.safetensors:  47%|████▋     | 3.03G/6.43G [00:15<00:15, 222MB/s]
17:52:25.244 model.safetensors:  48%|████▊     | 3.10G/6.43G [00:16<00:14, 228MB/s]
17:52:25.560 model.safetensors:  49%|████▉     | 3.16G/6.43G [00:16<00:13, 237MB/s]
17:52:25.848 model.safetensors:  50%|█████     | 3.23G/6.43G [00:16<00:13, 229MB/s]
17:52:26.177 model.safetensors:  51%|█████▏    | 3.30G/6.43G [00:17<00:13, 230MB/s]
17:52:26.446 model.safetensors:  52%|█████▏    | 3.36G/6.43G [00:17<00:14, 217MB/s]
17:52:26.713 model.safetensors:  53%|█████▎    | 3.43G/6.43G [00:17<00:13, 226MB/s]
17:52:27.046 model.safetensors:  54%|█████▍    | 3.49G/6.43G [00:17<00:12, 233MB/s]
17:52:27.313 model.safetensors:  55%|█████▌    | 3.56G/6.43G [00:18<00:12, 222MB/s]
17:52:27.566 model.safetensors:  56%|█████▋    | 3.63G/6.43G [00:18<00:12, 230MB/s]
17:52:27.824 model.safetensors:  57%|█████▋    | 3.70G/6.43G [00:18<00:11, 240MB/s]
17:52:28.153 model.safetensors:  58%|█████▊    | 3.76G/6.43G [00:19<00:10, 246MB/s]
17:52:28.408 model.safetensors:  60%|█████▉    | 3.83G/6.43G [00:19<00:11, 231MB/s]
17:52:28.691 model.safetensors:  61%|██████    | 3.90G/6.43G [00:19<00:10, 240MB/s]
17:52:28.948 model.safetensors:  62%|██████▏   | 3.96G/6.43G [00:19<00:10, 239MB/s]
17:52:29.296 model.safetensors:  63%|██████▎   | 4.03G/6.43G [00:20<00:09, 245MB/s]
17:52:29.581 model.safetensors:  64%|██████▎   | 4.09G/6.43G [00:20<00:10, 224MB/s]
17:52:29.887 model.safetensors:  65%|██████▍   | 4.16G/6.43G [00:20<00:10, 227MB/s]
17:52:30.209 model.safetensors:  66%|██████▌   | 4.23G/6.43G [00:21<00:09, 225MB/s]
17:52:30.509 model.safetensors:  67%|██████▋   | 4.30G/6.43G [00:21<00:09, 219MB/s]
17:52:30.810 model.safetensors:  68%|██████▊   | 4.36G/6.43G [00:21<00:09, 220MB/s]
17:52:31.102 model.safetensors:  69%|██████▊   | 4.41G/6.43G [00:22<00:09, 205MB/s]
17:52:31.775 model.safetensors:  70%|██████▉   | 4.48G/6.43G [00:22<00:09, 212MB/s]
17:52:32.093 model.safetensors:  71%|███████   | 4.55G/6.43G [00:23<00:12, 157MB/s]
17:52:32.467 model.safetensors:  72%|███████▏  | 4.61G/6.43G [00:23<00:10, 170MB/s]
17:52:32.769 model.safetensors:  73%|███████▎  | 4.68G/6.43G [00:23<00:10, 173MB/s]
17:52:33.100 model.safetensors:  74%|███████▍  | 4.75G/6.43G [00:24<00:09, 185MB/s]
17:52:33.384 model.safetensors:  75%|███████▍  | 4.81G/6.43G [00:24<00:08, 190MB/s]
17:52:33.705 model.safetensors:  76%|███████▌  | 4.88G/6.43G [00:24<00:07, 202MB/s]
17:52:34.002 model.safetensors:  77%|███████▋  | 4.95G/6.43G [00:24<00:07, 204MB/s]
17:52:34.360 model.safetensors:  79%|███████▉  | 5.09G/6.43G [00:25<00:04, 281MB/s]
17:52:34.777 model.safetensors:  80%|████████  | 5.16G/6.43G [00:25<00:05, 251MB/s]
17:52:35.062 model.safetensors:  81%|████████  | 5.23G/6.43G [00:26<00:05, 219MB/s]
17:52:35.382 model.safetensors:  82%|████████▏ | 5.29G/6.43G [00:26<00:05, 223MB/s]
17:52:35.677 model.safetensors:  83%|████████▎ | 5.36G/6.43G [00:26<00:04, 219MB/s]
17:52:35.973 model.safetensors:  84%|████████▍ | 5.43G/6.43G [00:26<00:04, 222MB/s]
17:52:36.203 model.safetensors:  85%|████████▌ | 5.49G/6.43G [00:27<00:04, 223MB/s]
17:52:36.503 model.safetensors:  86%|████████▋ | 5.56G/6.43G [00:27<00:03, 239MB/s]
17:52:36.823 model.safetensors:  87%|████████▋ | 5.63G/6.43G [00:27<00:03, 235MB/s]
17:52:37.052 model.safetensors:  89%|████████▊ | 5.69G/6.43G [00:28<00:03, 226MB/s]
17:52:37.352 model.safetensors:  91%|█████████ | 5.83G/6.43G [00:28<00:01, 315MB/s]
17:52:37.597 model.safetensors:  92%|█████████▏| 5.90G/6.43G [00:28<00:01, 286MB/s]
17:52:38.038 model.safetensors:  93%|█████████▎| 5.96G/6.43G [00:28<00:01, 283MB/s]
17:52:38.358 model.safetensors:  94%|█████████▎| 6.03G/6.43G [00:29<00:01, 229MB/s]
17:52:38.708 model.safetensors:  95%|█████████▍| 6.10G/6.43G [00:29<00:01, 223MB/s]
17:52:39.069 model.safetensors:  96%|█████████▌| 6.16G/6.43G [00:29<00:01, 213MB/s]
17:52:39.451 model.safetensors:  97%|█████████▋| 6.23G/6.43G [00:30<00:00, 205MB/s]
17:52:39.452 model.safetensors:  98%|█████████▊| 6.30G/6.43G [00:30<00:00, 195MB/s]
17:52:39.452 model.safetensors: 100%|██████████| 6.43G/6.43G [00:30<00:00, 210MB/s]
``
