### PR TITLE
feat: switch run command from polling to WebSocket streaming for logs

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cerebriumai/cerebrium/internal/api"
 	"github.com/cerebriumai/cerebrium/internal/ui"
 	uiCommands "github.com/cerebriumai/cerebrium/internal/ui/commands"
+	"github.com/cerebriumai/cerebrium/internal/wsapi"
 	"github.com/cerebriumai/cerebrium/pkg/config"
 	"github.com/cerebriumai/cerebrium/pkg/projectconfig"
 	tea "github.com/charmbracelet/bubbletea"
@@ -126,6 +127,9 @@ func runRun(cmd *cobra.Command, filename string, dataMap map[string]any, region 
 		return ui.NewValidationError(fmt.Errorf("failed to create API client: %w", err))
 	}
 
+	// Create websocket client for streaming app logs
+	wsClient := wsapi.NewClient(cfg)
+
 	// Create context with timeout for run polling
 	ctx, cancel := context.WithTimeout(cmd.Context(), runPollingTimeout)
 	defer cancel()
@@ -135,6 +139,7 @@ func runRun(cmd *cobra.Command, filename string, dataMap map[string]any, region 
 		Config:        projectConfig,
 		ProjectID:     cfg.ProjectID,
 		Client:        client,
+		WSClient:      wsClient,
 		Filename:      filename,
 		FunctionName:  functionName,
 		Region:        region,

--- a/internal/ui/logging/streaming_app_provider.go
+++ b/internal/ui/logging/streaming_app_provider.go
@@ -1,0 +1,89 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/cerebriumai/cerebrium/internal/wsapi"
+)
+
+type streamingAppProvider struct {
+	client    wsapi.Client
+	projectID string
+	appID     string
+	runID     string
+
+	// State for deduplication
+	seenIDs map[string]bool
+}
+
+// StreamingAppLogProviderConfig configures a streaming WebSocket provider for app runtime logs.
+type StreamingAppLogProviderConfig struct {
+	Client    wsapi.Client
+	ProjectID string
+	AppID     string
+	RunID     string // Optional: filter logs to a specific run
+}
+
+// NewStreamingAppLogProvider creates a new WebSocket streaming provider for app runtime logs.
+// This replaces the polling-based provider for real-time log delivery.
+func NewStreamingAppLogProvider(cfg StreamingAppLogProviderConfig) LogProvider {
+	return &streamingAppProvider{
+		client:    cfg.Client,
+		projectID: cfg.ProjectID,
+		appID:     cfg.AppID,
+		runID:     cfg.RunID,
+		seenIDs:   make(map[string]bool),
+	}
+}
+
+func (p *streamingAppProvider) Collect(ctx context.Context, callback func([]Log) error) error {
+	opts := wsapi.AppLogStreamOptions{
+		From:  time.Now().Add(-10 * time.Second), // Start from 10 seconds ago to catch recent logs
+		RunID: p.runID,
+	}
+
+	return p.client.StreamAppLogs(ctx, p.projectID, p.appID, opts, func(msg wsapi.AppLogMessage) error {
+		// Generate unique ID for deduplication
+		baseLogID := fmt.Sprintf("%s-%s-%s", msg.AppID, msg.RunID, msg.Timestamp.Format(time.RFC3339Nano))
+		if p.seenIDs[baseLogID] {
+			return nil
+		}
+		p.seenIDs[baseLogID] = true
+
+		// Strip ANSI cursor movement codes and normalize carriage returns
+		// (same processing as build logs for progress bar support)
+		cleanedLog := ansiCursorMovement.ReplaceAllString(msg.Log, "")
+		normalizedLog := strings.ReplaceAll(cleanedLog, "\r", "\n")
+		parts := strings.Split(normalizedLog, "\n")
+
+		var logs []Log
+		for i, part := range parts {
+			if strings.TrimSpace(part) == "" || isJustProcessPrefix(part) {
+				continue
+			}
+
+			logs = append(logs, Log{
+				ID:        fmt.Sprintf("%s-%d", baseLogID, i),
+				Timestamp: msg.Timestamp,
+				Content:   part,
+				Stream:    "stdout", // App logs don't have stream info from WebSocket
+				Metadata: map[string]any{
+					"appID":         msg.AppID,
+					"runID":         msg.RunID,
+					"containerName": msg.ContainerName,
+				},
+			})
+		}
+
+		if len(logs) == 0 {
+			return nil
+		}
+
+		slog.Debug("Streamed app logs", "count", len(logs), "runID", msg.RunID)
+		return callback(logs)
+	})
+}

--- a/internal/wsapi/client.go
+++ b/internal/wsapi/client.go
@@ -280,3 +280,176 @@ func (c *client) parseMessage(data []byte) (BuildLogMessage, error) {
 		Stage:      raw.Stage,
 	}, nil
 }
+
+// StreamAppLogs implements Client.StreamAppLogs.
+func (c *client) StreamAppLogs(ctx context.Context, projectID, appID string, opts AppLogStreamOptions, callback func(AppLogMessage) error) error {
+	reconnectAttempts := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		err := c.streamAppLogsOnce(ctx, projectID, appID, opts, callback)
+		if err == nil {
+			// Clean exit (server closed connection normally)
+			return nil
+		}
+
+		// Check if context was cancelled
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Handle reconnection
+		reconnectAttempts++
+		if reconnectAttempts > maxReconnectAttempts {
+			return fmt.Errorf("max reconnection attempts (%d) exceeded: %w", maxReconnectAttempts, err)
+		}
+
+		slog.Warn("WebSocket connection lost, reconnecting",
+			"attempt", reconnectAttempts,
+			"maxAttempts", maxReconnectAttempts,
+			"error", err,
+		)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(reconnectDelay):
+			// Continue to reconnect
+		}
+	}
+}
+
+// streamAppLogsOnce handles a single websocket connection session for app logs.
+func (c *client) streamAppLogsOnce(ctx context.Context, projectID, appID string, opts AppLogStreamOptions, callback func(AppLogMessage) error) error {
+	conn, err := c.connectAppLogs(ctx, projectID, appID, opts)
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck // Best effort close
+
+	// Set up pong handler for connection keep-alive
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(pingInterval + pongTimeout))
+	})
+
+	// Start ping ticker in background
+	pingDone := make(chan struct{})
+	go c.pingLoop(ctx, conn, pingDone)
+	defer close(pingDone)
+
+	// Read messages
+	for {
+		select {
+		case <-ctx.Done():
+			// Send close frame before exiting
+			_ = conn.WriteMessage(websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			return ctx.Err()
+		default:
+		}
+
+		// Set read deadline
+		if err := conn.SetReadDeadline(time.Now().Add(pingInterval + pongTimeout)); err != nil {
+			return fmt.Errorf("failed to set read deadline: %w", err)
+		}
+
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				slog.Debug("WebSocket closed normally")
+				return nil
+			}
+			return fmt.Errorf("read error: %w", err)
+		}
+
+		msg, err := c.parseAppLogMessage(message)
+		if err != nil {
+			slog.Warn("Failed to parse websocket message", "error", err)
+			continue
+		}
+
+		if err := callback(msg); err != nil {
+			return fmt.Errorf("callback error: %w", err)
+		}
+	}
+}
+
+// connectAppLogs establishes a websocket connection to the app logs endpoint.
+func (c *client) connectAppLogs(ctx context.Context, projectID, appID string, opts AppLogStreamOptions) (*websocket.Conn, error) {
+	// Get auth token
+	token, err := c.getAuthToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get auth token: %w", err)
+	}
+
+	// Build websocket URL with query parameters
+	baseURL := c.cfg.GetEnvConfig().LogStreamUrl
+	wsURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid logstream URL: %w", err)
+	}
+	wsURL.Path = "/ws-logs"
+
+	query := wsURL.Query()
+	query.Set("projectID", projectID)
+	query.Set("appID", appID)
+	query.Set("token", token)
+	if !opts.From.IsZero() {
+		query.Set("after", opts.From.Format(time.RFC3339Nano))
+	}
+	if opts.ContainerID != "" {
+		query.Set("containerID", opts.ContainerID)
+	}
+	if opts.RunID != "" {
+		query.Set("runID", opts.RunID)
+	}
+	wsURL.RawQuery = query.Encode()
+
+	slog.Debug("Connecting to app logs websocket",
+		"url", wsURL.Host+wsURL.Path,
+		"projectID", projectID,
+		"appID", appID,
+		"runID", opts.RunID,
+	)
+
+	// Connect with context
+	dialer := websocket.Dialer{
+		HandshakeTimeout: handshakeTimeout,
+	}
+
+	conn, resp, err := dialer.DialContext(ctx, wsURL.String(), nil)
+	if err != nil {
+		if resp != nil {
+			return nil, fmt.Errorf("websocket dial failed with status %d: %w", resp.StatusCode, err)
+		}
+		return nil, fmt.Errorf("websocket dial failed: %w", err)
+	}
+
+	slog.Info("Connected to app logs websocket",
+		"projectID", projectID,
+		"appID", appID,
+	)
+
+	return conn, nil
+}
+
+// parseAppLogMessage parses a raw websocket message into an AppLogMessage.
+func (c *client) parseAppLogMessage(data []byte) (AppLogMessage, error) {
+	var raw rawAppLogMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return AppLogMessage{}, fmt.Errorf("failed to unmarshal message: %w", err)
+	}
+
+	return AppLogMessage{
+		AppID:         raw.AppID,
+		RunID:         raw.RunID,
+		Timestamp:     parseTimestamp(raw.Timestamp),
+		ContainerName: raw.ContainerName,
+		Log:           raw.Log,
+	}, nil
+}

--- a/internal/wsapi/client.go
+++ b/internal/wsapi/client.go
@@ -42,10 +42,10 @@ func NewClient(cfg *config.Config) Client {
 
 // wsConnectConfig holds configuration for establishing a WebSocket connection.
 type wsConnectConfig struct {
-	path       string
-	projectID  string
-	queryParams map[string]string
-	logContext []any // key-value pairs for slog
+	path        string            // WebSocket endpoint path (e.g., "/ws-build-logs", "/ws-logs")
+	projectID   string            // Project ID for authentication
+	queryParams map[string]string // Additional query parameters (e.g., buildID, appID, runID)
+	logContext  []any             // Key-value pairs for structured logging
 }
 
 // streamWithReconnect is a generic WebSocket streaming function with reconnection logic.

--- a/internal/wsapi/client.go
+++ b/internal/wsapi/client.go
@@ -62,13 +62,16 @@ func (c *client) streamWithReconnect(ctx context.Context, cfg wsConnectConfig, m
 
 		err := c.streamOnce(ctx, cfg, messageHandler)
 		if err == nil {
-			return nil // Clean exit
+			// Clean exit (server closed connection normally)
+			return nil
 		}
 
+		// Check if context was cancelled
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
+		// Handle reconnection
 		reconnectAttempts++
 		if reconnectAttempts > maxReconnectAttempts {
 			return fmt.Errorf("max reconnection attempts (%d) exceeded: %w", maxReconnectAttempts, err)
@@ -84,6 +87,7 @@ func (c *client) streamWithReconnect(ctx context.Context, cfg wsConnectConfig, m
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-time.After(reconnectDelay):
+			// Continue to reconnect
 		}
 	}
 }

--- a/internal/wsapi/interface.go
+++ b/internal/wsapi/interface.go
@@ -17,4 +17,28 @@ type Client interface {
 	// Returns context.Canceled or context.DeadlineExceeded when the context is done.
 	// Returns an error if max reconnection attempts are exceeded or callback fails.
 	StreamBuildLogs(ctx context.Context, projectID, buildID string, from time.Time, callback func(BuildLogMessage) error) error
+
+	// StreamAppLogs connects to the app logs websocket and streams runtime log messages.
+	// The client handles connection management, reconnection on failures, and keep-alive.
+	//
+	// Options allow filtering by containerID and runID.
+	//
+	// The callback is invoked for each log message received. If the callback returns
+	// an error, streaming stops and that error is returned.
+	//
+	// Returns context.Canceled or context.DeadlineExceeded when the context is done.
+	// Returns an error if max reconnection attempts are exceeded or callback fails.
+	StreamAppLogs(ctx context.Context, projectID, appID string, opts AppLogStreamOptions, callback func(AppLogMessage) error) error
+}
+
+// AppLogStreamOptions contains options for streaming app logs.
+type AppLogStreamOptions struct {
+	// From is the timestamp to start streaming from (optional)
+	From time.Time
+
+	// ContainerID filters logs to a specific container (optional)
+	ContainerID string
+
+	// RunID filters logs to a specific run (optional)
+	RunID string
 }

--- a/internal/wsapi/mock/client_gen.go
+++ b/internal/wsapi/mock/client_gen.go
@@ -113,3 +113,78 @@ func (_c *MockClient_StreamBuildLogs_Call) RunAndReturn(run func(ctx context.Con
 	_c.Call.Return(run)
 	return _c
 }
+
+// StreamAppLogs provides a mock function for the type MockClient
+func (_mock *MockClient) StreamAppLogs(ctx context.Context, projectID string, appID string, opts wsapi.AppLogStreamOptions, callback func(wsapi.AppLogMessage) error) error {
+	ret := _mock.Called(ctx, projectID, appID, opts, callback)
+
+	if len(ret) == 0 {
+		panic("no return value specified for StreamAppLogs")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, wsapi.AppLogStreamOptions, func(wsapi.AppLogMessage) error) error); ok {
+		r0 = returnFunc(ctx, projectID, appID, opts, callback)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockClient_StreamAppLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StreamAppLogs'
+type MockClient_StreamAppLogs_Call struct {
+	*mock.Call
+}
+
+// StreamAppLogs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+//   - appID string
+//   - opts wsapi.AppLogStreamOptions
+//   - callback func(wsapi.AppLogMessage) error
+func (_e *MockClient_Expecter) StreamAppLogs(ctx interface{}, projectID interface{}, appID interface{}, opts interface{}, callback interface{}) *MockClient_StreamAppLogs_Call {
+	return &MockClient_StreamAppLogs_Call{Call: _e.mock.On("StreamAppLogs", ctx, projectID, appID, opts, callback)}
+}
+
+func (_c *MockClient_StreamAppLogs_Call) Run(run func(ctx context.Context, projectID string, appID string, opts wsapi.AppLogStreamOptions, callback func(wsapi.AppLogMessage) error)) *MockClient_StreamAppLogs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 wsapi.AppLogStreamOptions
+		if args[3] != nil {
+			arg3 = args[3].(wsapi.AppLogStreamOptions)
+		}
+		var arg4 func(wsapi.AppLogMessage) error
+		if args[4] != nil {
+			arg4 = args[4].(func(wsapi.AppLogMessage) error)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_StreamAppLogs_Call) Return(err error) *MockClient_StreamAppLogs_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockClient_StreamAppLogs_Call) RunAndReturn(run func(ctx context.Context, projectID string, appID string, opts wsapi.AppLogStreamOptions, callback func(wsapi.AppLogMessage) error) error) *MockClient_StreamAppLogs_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/wsapi/types.go
+++ b/internal/wsapi/types.go
@@ -43,6 +43,33 @@ type rawBuildLogMessage struct {
 	Stage      string `json:"stage"`
 }
 
+// AppLogMessage represents an app runtime log entry received from the websocket stream.
+type AppLogMessage struct {
+	// AppID is the application identifier
+	AppID string
+
+	// RunID is the run identifier (optional, for filtering)
+	RunID string
+
+	// Timestamp is when the log was created (parsed to local timezone)
+	Timestamp time.Time
+
+	// ContainerName is the container that produced the log
+	ContainerName string
+
+	// Log is the actual log message content
+	Log string
+}
+
+// rawAppLogMessage is the JSON structure received from the websocket server for app logs.
+type rawAppLogMessage struct {
+	AppID         string `json:"app_id"`
+	RunID         string `json:"run_id"`
+	Timestamp     string `json:"timestamp"`
+	ContainerName string `json:"container_name"`
+	Log           string `json:"log"`
+}
+
 // parseTimestamp parses a timestamp string and converts it to local timezone.
 func parseTimestamp(ts string) time.Time {
 	// Try RFC3339Nano first (most precise)


### PR DESCRIPTION
## Problem
The `cerebrium run` command used HTTP polling (every 5 seconds) to fetch logs, causing:
- Logs to arrive in batches with delays
- Potential missing logs between polls
- Poor real-time experience for users

## Solution
Switch to WebSocket streaming using the existing `/ws-logs` endpoint (same as the dashboard uses), providing:
- Real-time log delivery as they're generated
- Ordered logs (Kafka maintains order)
- No missing logs
- Same infrastructure as dashboard

## Changes
- Added `StreamAppLogs` method to wsapi client for WebSocket app log streaming
- Created `streaming_app_provider.go` with WebSocket-based log provider
- Updated `run.go` to use streaming provider instead of polling
- Added `AppLogMessage` and related types for app log parsing

## Testing
Tested with a Python app that outputs logs every 0.5 seconds:

**- Before: NO LOGS** 
<img width="565" height="268" alt="Screenshot 2026-01-30 at 12 15 11 PM" src="https://github.com/user-attachments/assets/90132d4f-fa90-41cc-acde-b7db18e954f5" />

**- After: Logs arrive in real-time with ~0.5s intervals between timestamps**
<img width="793" height="320" alt="Screenshot 2026-01-30 at 12 15 31 PM" src="https://github.com/user-attachments/assets/1a2ce961-b77d-48a7-a2cb-9da88c49f130" />

## Backward Compatibility
- All existing tests pass