### PR TITLE
fix(run): support requirements.txt and improve base image timeout

### DIFF
--- a/internal/ui/commands/run.go
+++ b/internal/ui/commands/run.go
@@ -186,9 +186,13 @@ func (m *RunView) handleRunPrepared(msg runPreparedMsg) (tea.Model, tea.Cmd) {
 
 	// Check if we need to create a base image for dependencies
 	// We track this here but create the app first (required for base-image API auth)
+	// Support both inline dependencies and file paths (e.g., requirements.txt)
 	m.needsBaseImage = m.conf.Config != nil && (len(m.conf.Config.Dependencies.Pip) > 0 ||
 		len(m.conf.Config.Dependencies.Conda) > 0 ||
-		len(m.conf.Config.Dependencies.Apt) > 0)
+		len(m.conf.Config.Dependencies.Apt) > 0 ||
+		m.conf.Config.Dependencies.Paths.Pip != "" ||
+		m.conf.Config.Dependencies.Paths.Conda != "" ||
+		m.conf.Config.Dependencies.Paths.Apt != "")
 
 	if m.conf.SimpleOutput() {
 		fmt.Printf("✓ Prepared %d files\n", len(msg.fileList))
@@ -666,10 +670,17 @@ func (m *RunView) prepareRun() tea.Msg {
 }
 
 func (m *RunView) createBaseImage() tea.Msg {
+	// Use the same dependency resolution as deploy - handles file paths, validation, etc.
+	depFiles, err := files.GenerateDependencyFiles(m.conf.Config)
+	if err != nil {
+		return ui.NewValidationError(fmt.Errorf("failed to process dependencies: %w", err))
+	}
+
+	// Parse the generated file contents back into maps for the base-image API
 	depsJSON := map[string]any{
-		"pip":   m.conf.Config.Dependencies.Pip,
-		"conda": m.conf.Config.Dependencies.Conda,
-		"apt":   m.conf.Config.Dependencies.Apt,
+		"pip":   files.ParseRequirementsContent(depFiles["requirements.txt"]),
+		"conda": files.ParseRequirementsContent(depFiles["conda_pkglist.txt"]),
+		"apt":   files.ParseRequirementsContent(depFiles["pkglist.txt"]),
 	}
 
 	depsBytes, err := json.Marshal(depsJSON)

--- a/internal/ui/commands/run.go
+++ b/internal/ui/commands/run.go
@@ -237,7 +237,7 @@ func (m *RunView) handleAppCreated() (tea.Model, tea.Cmd) {
 		m.state = RunStateCheckingDependencies
 
 		if m.conf.SimpleOutput() {
-			fmt.Println("Checking dependencies...")
+			fmt.Println("Building base image...")
 			return m, m.createBaseImage
 		}
 
@@ -475,7 +475,7 @@ func (m *RunView) View() string {
 		output.WriteString(formatStateLine("-", "Create run app", ui.PendingStyle.Render))
 		output.WriteString("\n")
 		if m.needsBaseImage {
-			output.WriteString(formatStateLine("-", "Check dependencies", ui.PendingStyle.Render))
+			output.WriteString(formatStateLine("-", "Build base image", ui.PendingStyle.Render))
 			output.WriteString("\n")
 		}
 		output.WriteString(formatStateLine("-", "Create archive", ui.PendingStyle.Render))
@@ -489,7 +489,7 @@ func (m *RunView) View() string {
 		output.WriteString(formatStateLine(m.spinner.View(), "Creating run app...", ui.ActiveStyle.Render))
 		output.WriteString("\n")
 		if m.needsBaseImage {
-			output.WriteString(formatStateLine("-", "Check dependencies", ui.PendingStyle.Render))
+			output.WriteString(formatStateLine("-", "Build base image", ui.PendingStyle.Render))
 			output.WriteString("\n")
 		}
 		output.WriteString(formatStateLine("-", "Create archive", ui.PendingStyle.Render))
@@ -500,7 +500,7 @@ func (m *RunView) View() string {
 		output.WriteString("\n")
 
 	case RunStateCheckingDependencies, RunStateCreatingBaseImage:
-		output.WriteString(formatStateLine(m.spinner.View(), "Checking dependencies...", ui.ActiveStyle.Render))
+		output.WriteString(formatStateLine(m.spinner.View(), "Building base image...", ui.ActiveStyle.Render))
 		output.WriteString("\n")
 		output.WriteString(formatStateLine("-", "Create archive", ui.PendingStyle.Render))
 		output.WriteString("\n")


### PR DESCRIPTION
## Summary

This PR fixes cerebrium run to properly support file-based dependencies (e.g., requirements.txt) and improves the base image build timeout.

**Problem**
When using cerebrium run with file-based dependencies:

```
[cerebrium.dependencies.paths]
pip = "requirements.txt"
```

The CLI would silently ignore the requirements file, resulting in ModuleNotFoundError at runtime because dependencies were never installed.

**Solution**

### 1. Support file-based dependencies

The CLI now properly detects and processes requirements.txt (and conda_pkglist.txt, pkglist.txt) when specified via [cerebrium.dependencies.paths].

**Before:**

```
✓ Prepared 3 files
✓ Created run app: my-app
✓ Created archive (5.0 KB)      # No base image step!
✓ Uploaded successfully
Executing...
ModuleNotFoundError: No module named 'requests'
```

**After:**

```
✓ Prepared 3 files
✓ Created run app: my-app
Building base image with dependencies (this may take up to 2 minutes)...
✓ Base image ready: 45548c9b...
✓ Created archive (5.0 KB)
✓ Uploaded successfully
Executing...
requests version: 2.32.5
```

### 2. Increase base image timeout (30s → 2 minutes)

Fresh base image builds can take longer than 30 seconds for heavier dependencies. The timeout is now 2 minutes with a clearer error message if it still times out.

### 3. Better error handling

Missing file: `Error: the specified file 'nonexistent.txt' was not found`
Both inline AND file specified: `Error: both requirements.txt and dependencies specified in config - please specify only one`

