### PR TITLE
fix: return non-zero exit code on command errors with SilentExit

### DIFF
--- a/cmd/cerebrium/main.go
+++ b/cmd/cerebrium/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/cerebriumai/cerebrium/internal/commands"
+	ui "github.com/cerebriumai/cerebrium/internal/ui"
 	cerebrium_bugsnag "github.com/cerebriumai/cerebrium/pkg/bugsnag"
 )
 
@@ -22,6 +24,15 @@ func main() {
 
 	rootCmd := commands.NewRootCmd()
 	if err := rootCmd.Execute(); err != nil {
+		// Check if this is a UIError with SilentExit (already shown in UI)
+		var uiErr *ui.UIError
+		if errors.As(err, &uiErr) && uiErr.SilentExit {
+			if uiErr.Type == ui.ErrorTypeUserCancelled {
+				os.Exit(0)
+			}
+			os.Exit(1)
+		}
+
 		// Commands handle their own error presentation logic
 		// If we get an error here, check if it's an unknown command error
 		// and show usage if so

--- a/internal/commands/apps/delete.go
+++ b/internal/commands/apps/delete.go
@@ -1,7 +1,6 @@
 package apps
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -100,11 +99,8 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unexpected model type")
 	}
 
-	// Check if there were any errors during execution
-	// Handle UIError - check if it should be silent
-	var uiErr *ui.UIError
-	if errors.As(m.Error(), &uiErr) && !uiErr.SilentExit {
-		return uiErr
+	if err := m.Error(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/commands/apps/get.go
+++ b/internal/commands/apps/get.go
@@ -1,7 +1,6 @@
 package apps
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cerebriumai/cerebrium/internal/api"
@@ -94,11 +93,8 @@ func runGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unexpected model type")
 	}
 
-	// Check if there were any errors during execution
-	// Handle UIError - check if it should be silent
-	var uiErr *ui.UIError
-	if errors.As(m.Error(), &uiErr) && !uiErr.SilentExit {
-		return uiErr
+	if err := m.Error(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/commands/apps/scale.go
+++ b/internal/commands/apps/scale.go
@@ -1,7 +1,6 @@
 package apps
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -138,11 +137,8 @@ func runScale(cmd *cobra.Command, args []string, cooldown, minReplicas, maxRepli
 		return fmt.Errorf("unexpected model type")
 	}
 
-	// Check if there were any errors during execution
-	// Handle UIError - check if it should be silent
-	var uiErr *ui.UIError
-	if errors.As(m.Error(), &uiErr) && !uiErr.SilentExit {
-		return uiErr
+	if err := m.Error(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -193,11 +193,6 @@ func runDeploy(cmd *cobra.Command, opts deployOptions, disableConfirmation bool)
 
 	// Handle error from model
 	if uiErr := m.GetError(); uiErr != nil {
-		if uiErr.SilentExit {
-			// Error was already shown in UI or should be silent - exit cleanly
-			return nil
-		}
-		// Return error for Cobra/main.go to print
 		return uiErr
 	}
 

--- a/internal/commands/files/cp.go
+++ b/internal/commands/files/cp.go
@@ -1,7 +1,6 @@
 package files
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -127,11 +126,8 @@ func runCp(cmd *cobra.Command, args []string, region string) error {
 		return fmt.Errorf("unexpected model type")
 	}
 
-	// Check for errors
-	// Handle UIError - check if it should be silent
-	var uiErr *ui.UIError
-	if errors.As(m.Error(), &uiErr) && !uiErr.SilentExit {
-		return uiErr
+	if err := m.Error(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/commands/files/download.go
+++ b/internal/commands/files/download.go
@@ -1,7 +1,6 @@
 package files
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -128,11 +127,8 @@ func runDownload(cmd *cobra.Command, args []string, region string) error {
 		return fmt.Errorf("unexpected model type")
 	}
 
-	// Check for errors
-	// Handle UIError - check if it should be silent
-	var uiErr *ui.UIError
-	if errors.As(m.Error(), &uiErr) && !uiErr.SilentExit {
-		return uiErr
+	if err := m.Error(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/commands/login.go
+++ b/internal/commands/login.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -86,14 +85,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// Check if there were any errors during execution
 	if m, ok := finalModel.(*uiCommands.LoginView); ok {
 		if uiErr := m.GetError(); uiErr != nil {
-			// Handle UIError
-			var uiErrTyped *ui.UIError
-			if errors.As(uiErr, &uiErrTyped) && !uiErrTyped.SilentExit {
-				// Error was already shown in UI or should be silent
-				return uiErr
-			}
-			// Return error for printing
-			return nil
+			return uiErr
 		}
 	}
 

--- a/internal/commands/logs.go
+++ b/internal/commands/logs.go
@@ -124,9 +124,6 @@ func runLogsCommand(cmd *cobra.Command, appName string, noFollow bool, since str
 	//nolint:errcheck // Type assertion guaranteed by Bubbletea model structure
 	m := finalModel.(*uiCommands.LogsView)
 	if uiErr := m.GetError(); uiErr != nil {
-		if uiErr.SilentExit {
-			return nil
-		}
 		return uiErr
 	}
 

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -170,9 +170,6 @@ func runRun(cmd *cobra.Command, filename string, dataMap map[string]any, region 
 	}
 
 	if uiErr := m.GetError(); uiErr != nil {
-		if uiErr.SilentExit {
-			return nil
-		}
 		return uiErr
 	}
 

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -99,11 +99,6 @@ func runStatus(cmd *cobra.Command, outputFormat string) error {
 
 	// Handle error from model
 	if uiErr := m.GetError(); uiErr != nil {
-		if uiErr.SilentExit {
-			// Error was already shown in UI or should be silent - exit cleanly
-			return nil
-		}
-		// Return error for Cobra/main.go to print
 		return uiErr
 	}
 


### PR DESCRIPTION
SilentExit was conflating "don't print error again" with "exit 0", causing commands like cp and deploy to exit 0 on real failures. Move SilentExit handling to main.go so errors are still silent but exit 1. User cancellation (Ctrl+C) continues to exit 0.