### PR TITLE
fix: include compute_tier in create-app payload

### DIFF
--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -160,6 +160,9 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 	if pc.Scaling.LoadBalancingAlgorithm != nil {
 		payload["loadBalancingAlgorithm"] = *pc.Scaling.LoadBalancingAlgorithm
 	}
+	if pc.Scaling.ComputeTier != nil {
+		payload["computeTier"] = *pc.Scaling.ComputeTier
+	}
 
 	// Runtime configuration
 	if pc.CustomRuntime != nil && pc.PartnerService != nil {


### PR DESCRIPTION
## Summary
- `ToPayload()` mapped every scaling field except `ComputeTier`, so `compute_tier = "protected"` in `cerebrium.toml` was silently dropped from the API request body
- Companion backend PR: CerebriumAI/dashboard-backend — `jono/fix-compute-tier-in-create-app`

## Test plan
- [ ] Set `compute_tier = "protected"` in cerebrium.toml and deploy — verify `computeTier` appears in the request body
- [ ] Deploy without `compute_tier` set — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)