### PR TITLE
Add GPU fallback support via unified compute field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-version v1.7.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/termenv v0.16.0
@@ -34,9 +36,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect

--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -1410,7 +1410,7 @@ func (m *DeployView) renderDeploymentSummary() string {
 		if m.conf.Config.Hardware.Memory != nil {
 			hardwareItems = append(hardwareItems, fmt.Sprintf("Memory: %.0f GB", *m.conf.Config.Hardware.Memory))
 		}
-		if m.conf.Config.Hardware.GPUCount != nil && m.conf.Config.Hardware.Compute.IsSet() && m.conf.Config.Hardware.Compute.Primary() != "CPU" {
+		if m.conf.Config.Hardware.GPUCount != nil {
 			hardwareItems = append(hardwareItems, fmt.Sprintf("GPU Count: %d", *m.conf.Config.Hardware.GPUCount))
 		}
 		if m.conf.Config.Hardware.Region != nil {
@@ -1558,7 +1558,7 @@ func (m *DeployView) renderDeploymentSummary() string {
 	if m.conf.Config.Hardware.Memory != nil {
 		hardwareRows = append(hardwareRows, ui.TableRow{Label: "Memory:", Value: fmt.Sprintf("%.0f GB", *m.conf.Config.Hardware.Memory)})
 	}
-	if m.conf.Config.Hardware.GPUCount != nil && m.conf.Config.Hardware.Compute.IsSet() && m.conf.Config.Hardware.Compute.Primary() != "CPU" {
+	if m.conf.Config.Hardware.GPUCount != nil {
 		hardwareRows = append(hardwareRows, ui.TableRow{Label: "GPU Count:", Value: fmt.Sprintf("%d", *m.conf.Config.Hardware.GPUCount)})
 	}
 	if m.conf.Config.Hardware.Region != nil {

--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -1402,10 +1402,7 @@ func (m *DeployView) renderDeploymentSummary() string {
 		// HARDWARE PARAMETERS
 		var hardwareItems []string
 		if m.conf.Config.Hardware.Compute.IsSet() {
-			hardwareItems = append(hardwareItems, fmt.Sprintf("Compute: %s", m.conf.Config.Hardware.Compute.Primary()))
-			if fallbacks := m.conf.Config.Hardware.Compute.Fallbacks(); len(fallbacks) > 0 {
-				hardwareItems = append(hardwareItems, fmt.Sprintf("Compute Fallbacks: %s", strings.Join(fallbacks, ", ")))
-			}
+			hardwareItems = append(hardwareItems, fmt.Sprintf("Compute: %s", m.conf.Config.Hardware.Compute))
 		}
 		if m.conf.Config.Hardware.CPU != nil {
 			hardwareItems = append(hardwareItems, fmt.Sprintf("CPU: %.1f", *m.conf.Config.Hardware.CPU))
@@ -1553,10 +1550,7 @@ func (m *DeployView) renderDeploymentSummary() string {
 	// HARDWARE PARAMETERS
 	var hardwareRows []ui.TableRow
 	if m.conf.Config.Hardware.Compute.IsSet() {
-		hardwareRows = append(hardwareRows, ui.TableRow{Label: "Compute:", Value: m.conf.Config.Hardware.Compute.Primary()})
-		if fallbacks := m.conf.Config.Hardware.Compute.Fallbacks(); len(fallbacks) > 0 {
-			hardwareRows = append(hardwareRows, ui.TableRow{Label: "Compute Fallbacks:", Value: strings.Join(fallbacks, ", ")})
-		}
+		hardwareRows = append(hardwareRows, ui.TableRow{Label: "Compute:", Value: m.conf.Config.Hardware.Compute.String()})
 	}
 	if m.conf.Config.Hardware.CPU != nil {
 		hardwareRows = append(hardwareRows, ui.TableRow{Label: "CPU:", Value: fmt.Sprintf("%.1f", *m.conf.Config.Hardware.CPU)})

--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -121,14 +121,14 @@ func NewDeployView(ctx context.Context, conf DeployConfig) *DeployView {
 	ctx, cancel := context.WithCancel(ctx)
 
 	return &DeployView{
-		ctx:             ctx,
-		ctxCancel:       cancel,
-		state:           initialState,
-		isPartnerDeploy: isPartnerDeploy,
-		spinner:         ui.NewSpinner(),
-		progressBar:     prog,
+		ctx:                 ctx,
+		ctxCancel:           cancel,
+		state:               initialState,
+		isPartnerDeploy:     isPartnerDeploy,
+		spinner:             ui.NewSpinner(),
+		progressBar:         prog,
 		atomicBytesUploaded: &atomic.Int64{},
-		conf:            conf,
+		conf:                conf,
 	}
 }
 
@@ -1401,8 +1401,11 @@ func (m *DeployView) renderDeploymentSummary() string {
 
 		// HARDWARE PARAMETERS
 		var hardwareItems []string
-		if m.conf.Config.Hardware.Compute != nil {
-			hardwareItems = append(hardwareItems, fmt.Sprintf("Compute: %s", *m.conf.Config.Hardware.Compute))
+		if m.conf.Config.Hardware.Compute.IsSet() {
+			hardwareItems = append(hardwareItems, fmt.Sprintf("Compute: %s", m.conf.Config.Hardware.Compute.Primary()))
+			if fallbacks := m.conf.Config.Hardware.Compute.Fallbacks(); len(fallbacks) > 0 {
+				hardwareItems = append(hardwareItems, fmt.Sprintf("Compute Fallbacks: %s", strings.Join(fallbacks, ", ")))
+			}
 		}
 		if m.conf.Config.Hardware.CPU != nil {
 			hardwareItems = append(hardwareItems, fmt.Sprintf("CPU: %.1f", *m.conf.Config.Hardware.CPU))
@@ -1410,7 +1413,7 @@ func (m *DeployView) renderDeploymentSummary() string {
 		if m.conf.Config.Hardware.Memory != nil {
 			hardwareItems = append(hardwareItems, fmt.Sprintf("Memory: %.0f GB", *m.conf.Config.Hardware.Memory))
 		}
-		if m.conf.Config.Hardware.GPUCount != nil && m.conf.Config.Hardware.Compute != nil && *m.conf.Config.Hardware.Compute != "CPU" {
+		if m.conf.Config.Hardware.GPUCount != nil && m.conf.Config.Hardware.Compute.IsSet() && m.conf.Config.Hardware.Compute.Primary() != "CPU" {
 			hardwareItems = append(hardwareItems, fmt.Sprintf("GPU Count: %d", *m.conf.Config.Hardware.GPUCount))
 		}
 		if m.conf.Config.Hardware.Region != nil {
@@ -1469,7 +1472,7 @@ func (m *DeployView) renderDeploymentSummary() string {
 			concurrency := fmt.Sprintf("Replica Concurrency: %d", *m.conf.Config.Scaling.ReplicaConcurrency)
 
 			// Add GPU warning if applicable
-			if m.conf.Config.Hardware.Compute != nil && *m.conf.Config.Hardware.Compute != "CPU" && *m.conf.Config.Scaling.ReplicaConcurrency > 1 {
+			if m.conf.Config.Hardware.Compute.IsSet() && m.conf.Config.Hardware.Compute.Primary() != "CPU" && *m.conf.Config.Scaling.ReplicaConcurrency > 1 {
 				concurrency += " ⚠️  (Multiple concurrent requests on GPU)"
 			}
 			scalingItems = append(scalingItems, concurrency)
@@ -1549,8 +1552,11 @@ func (m *DeployView) renderDeploymentSummary() string {
 
 	// HARDWARE PARAMETERS
 	var hardwareRows []ui.TableRow
-	if m.conf.Config.Hardware.Compute != nil {
-		hardwareRows = append(hardwareRows, ui.TableRow{Label: "Compute:", Value: *m.conf.Config.Hardware.Compute})
+	if m.conf.Config.Hardware.Compute.IsSet() {
+		hardwareRows = append(hardwareRows, ui.TableRow{Label: "Compute:", Value: m.conf.Config.Hardware.Compute.Primary()})
+		if fallbacks := m.conf.Config.Hardware.Compute.Fallbacks(); len(fallbacks) > 0 {
+			hardwareRows = append(hardwareRows, ui.TableRow{Label: "Compute Fallbacks:", Value: strings.Join(fallbacks, ", ")})
+		}
 	}
 	if m.conf.Config.Hardware.CPU != nil {
 		hardwareRows = append(hardwareRows, ui.TableRow{Label: "CPU:", Value: fmt.Sprintf("%.1f", *m.conf.Config.Hardware.CPU)})
@@ -1558,7 +1564,7 @@ func (m *DeployView) renderDeploymentSummary() string {
 	if m.conf.Config.Hardware.Memory != nil {
 		hardwareRows = append(hardwareRows, ui.TableRow{Label: "Memory:", Value: fmt.Sprintf("%.0f GB", *m.conf.Config.Hardware.Memory)})
 	}
-	if m.conf.Config.Hardware.GPUCount != nil && m.conf.Config.Hardware.Compute != nil && *m.conf.Config.Hardware.Compute != "CPU" {
+	if m.conf.Config.Hardware.GPUCount != nil && m.conf.Config.Hardware.Compute.IsSet() && m.conf.Config.Hardware.Compute.Primary() != "CPU" {
 		hardwareRows = append(hardwareRows, ui.TableRow{Label: "GPU Count:", Value: fmt.Sprintf("%d", *m.conf.Config.Hardware.GPUCount)})
 	}
 	if m.conf.Config.Hardware.Region != nil {
@@ -1636,7 +1642,7 @@ func (m *DeployView) renderDeploymentSummary() string {
 		concurrency := fmt.Sprintf("%d", *m.conf.Config.Scaling.ReplicaConcurrency)
 
 		// Add GPU warning if applicable
-		if m.conf.Config.Hardware.Compute != nil && *m.conf.Config.Hardware.Compute != "CPU" && *m.conf.Config.Scaling.ReplicaConcurrency > 1 {
+		if m.conf.Config.Hardware.Compute.IsSet() && m.conf.Config.Hardware.Compute.Primary() != "CPU" && *m.conf.Config.Scaling.ReplicaConcurrency > 1 {
 			concurrency += " ⚠️  (Multiple concurrent requests on GPU)"
 		}
 		scalingRows = append(scalingRows, ui.TableRow{Label: "Replica Concurrency:", Value: concurrency})

--- a/internal/ui/commands/deploy_test.go
+++ b/internal/ui/commands/deploy_test.go
@@ -128,7 +128,6 @@ func TestDeployView(t *testing.T) {
 		mockClient := apimock.NewMockClient(t)
 
 		// Create a comprehensive config to test the display
-		compute := "NVIDIA_A10"
 		cpu := 2.0
 		memory := 8.0
 		gpuCount := 1
@@ -147,7 +146,7 @@ func TestDeployView(t *testing.T) {
 				Exclude:       []string{"__pycache__", "*.pyc"},
 			},
 			Hardware: projectconfig.HardwareConfig{
-				Compute:  &compute,
+				Compute:  projectconfig.ComputeField{"NVIDIA_A10"},
 				CPU:      &cpu,
 				Memory:   &memory,
 				GPUCount: &gpuCount,

--- a/internal/ui/commands/run.go
+++ b/internal/ui/commands/run.go
@@ -617,8 +617,8 @@ func (m *RunView) prepareRun() tea.Msg {
 	hardwareInfo := ""
 	if m.conf.Config != nil {
 		var info []string
-		if m.conf.Config.Hardware.Compute != nil && *m.conf.Config.Hardware.Compute != "" {
-			info = append(info, fmt.Sprintf("Compute: %s", *m.conf.Config.Hardware.Compute))
+		if m.conf.Config.Hardware.Compute.IsSet() {
+			info = append(info, fmt.Sprintf("Compute: %s", m.conf.Config.Hardware.Compute.Primary()))
 		}
 		if m.conf.Config.Hardware.GPUCount != nil && *m.conf.Config.Hardware.GPUCount > 0 {
 			info = append(info, fmt.Sprintf("GPU: %d", *m.conf.Config.Hardware.GPUCount))
@@ -848,8 +848,8 @@ func (m *RunView) uploadRun() tea.Msg {
 	// Build hardware config
 	hardwareConfig := make(map[string]any)
 	if m.conf.Config != nil {
-		if m.conf.Config.Hardware.Compute != nil && *m.conf.Config.Hardware.Compute != "" {
-			hardwareConfig["computeType"] = *m.conf.Config.Hardware.Compute
+		if m.conf.Config.Hardware.Compute.IsSet() {
+			hardwareConfig["computeType"] = m.conf.Config.Hardware.Compute.Primary()
 		}
 		if m.conf.Config.Hardware.GPUCount != nil && *m.conf.Config.Hardware.GPUCount > 0 {
 			hardwareConfig["gpuCount"] = *m.conf.Config.Hardware.GPUCount

--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -1,5 +1,7 @@
 package projectconfig
 
+import "strings"
+
 // ProjectConfig represents the complete cerebrium.toml configuration
 type ProjectConfig struct {
 	Deployment     DeploymentConfig      `mapstructure:"deployment" toml:"deployment"`
@@ -65,6 +67,12 @@ func (c ComputeField) Fallbacks() []string {
 // IsSet reports whether compute was configured in any form.
 func (c ComputeField) IsSet() bool {
 	return len(c) > 0
+}
+
+// String renders the configured compute types as a comma-separated list for
+// display, e.g. "HOPPER_H100, HOPPER_H200".
+func (c ComputeField) String() string {
+	return strings.Join(c, ", ")
 }
 
 // ScalingConfig represents the [cerebrium.scaling] section
@@ -151,11 +159,9 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		payload["memory"] = *pc.Hardware.Memory
 	}
 	if pc.Hardware.Compute.IsSet() {
-		if len(pc.Hardware.Compute) == 1 {
-			payload["compute"] = pc.Hardware.Compute.Primary()
-		} else {
-			payload["compute"] = []string(pc.Hardware.Compute)
-		}
+		// The backend accepts either a string or a string[], so always send the
+		// slice and let it decide how to interpret primary vs. fallbacks.
+		payload["compute"] = []string(pc.Hardware.Compute)
 	}
 	if pc.Hardware.GPUCount != nil && pc.Hardware.Compute.IsSet() && pc.Hardware.Compute.Primary() != "CPU" {
 		payload["gpuCount"] = *pc.Hardware.GPUCount

--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -30,12 +30,14 @@ type DeploymentConfig struct {
 
 // HardwareConfig represents the [cerebrium.hardware] section
 type HardwareConfig struct {
-	CPU      *float64 `mapstructure:"cpu" toml:"cpu,omitempty"`
-	Memory   *float64 `mapstructure:"memory" toml:"memory,omitempty"`
-	Compute  *string  `mapstructure:"compute" toml:"compute,omitempty"`
-	GPUCount *int     `mapstructure:"gpu_count" toml:"gpu_count,omitempty"`
-	Provider *string  `mapstructure:"provider" toml:"provider,omitempty"`
-	Region   *string  `mapstructure:"region" toml:"region,omitempty"`
+	CPU              *float64    `mapstructure:"cpu" toml:"cpu,omitempty"`
+	Memory           *float64    `mapstructure:"memory" toml:"memory,omitempty"`
+	ComputeRaw       interface{} `mapstructure:"compute" toml:"compute,omitempty"`
+	Compute          *string     `mapstructure:"-" toml:"-"`
+	ComputeFallbacks []string    `mapstructure:"-" toml:"-"`
+	GPUCount         *int        `mapstructure:"gpu_count" toml:"gpu_count,omitempty"`
+	Provider         *string     `mapstructure:"provider" toml:"provider,omitempty"`
+	Region           *string     `mapstructure:"region" toml:"region,omitempty"`
 }
 
 // ScalingConfig represents the [cerebrium.scaling] section
@@ -122,7 +124,12 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		payload["memory"] = *pc.Hardware.Memory
 	}
 	if pc.Hardware.Compute != nil {
-		payload["compute"] = *pc.Hardware.Compute
+		if len(pc.Hardware.ComputeFallbacks) > 0 {
+			all := append([]string{*pc.Hardware.Compute}, pc.Hardware.ComputeFallbacks...)
+			payload["compute"] = all
+		} else {
+			payload["compute"] = *pc.Hardware.Compute
+		}
 	}
 	if pc.Hardware.GPUCount != nil && pc.Hardware.Compute != nil && *pc.Hardware.Compute != "CPU" {
 		payload["gpuCount"] = *pc.Hardware.GPUCount

--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -30,14 +30,41 @@ type DeploymentConfig struct {
 
 // HardwareConfig represents the [cerebrium.hardware] section
 type HardwareConfig struct {
-	CPU              *float64    `mapstructure:"cpu" toml:"cpu,omitempty"`
-	Memory           *float64    `mapstructure:"memory" toml:"memory,omitempty"`
-	ComputeRaw       interface{} `mapstructure:"compute" toml:"compute,omitempty"`
-	Compute          *string     `mapstructure:"-" toml:"-"`
-	ComputeFallbacks []string    `mapstructure:"-" toml:"-"`
-	GPUCount         *int        `mapstructure:"gpu_count" toml:"gpu_count,omitempty"`
-	Provider         *string     `mapstructure:"provider" toml:"provider,omitempty"`
-	Region           *string     `mapstructure:"region" toml:"region,omitempty"`
+	CPU      *float64     `mapstructure:"cpu" toml:"cpu,omitempty"`
+	Memory   *float64     `mapstructure:"memory" toml:"memory,omitempty"`
+	Compute  ComputeField `mapstructure:"compute" toml:"compute,omitempty"`
+	GPUCount *int         `mapstructure:"gpu_count" toml:"gpu_count,omitempty"`
+	Provider *string      `mapstructure:"provider" toml:"provider,omitempty"`
+	Region   *string      `mapstructure:"region" toml:"region,omitempty"`
+}
+
+// ComputeField accepts either a single value (`compute = "HOPPER_H100"`) or an
+// array (`compute = ["HOPPER_H100", "HOPPER_H200"]`). The first element is the
+// preferred compute type; the remainder are fallbacks the backend may schedule
+// onto when the primary is unavailable. Mirrors the backend's StringOrStrings
+// type so the CLI's in-memory model matches the wire format.
+type ComputeField []string
+
+// Primary returns the requested compute type, or "" when unset.
+func (c ComputeField) Primary() string {
+	if len(c) == 0 {
+		return ""
+	}
+	return c[0]
+}
+
+// Fallbacks returns the alternate compute types in priority order, or nil when
+// only a primary was configured.
+func (c ComputeField) Fallbacks() []string {
+	if len(c) <= 1 {
+		return nil
+	}
+	return c[1:]
+}
+
+// IsSet reports whether compute was configured in any form.
+func (c ComputeField) IsSet() bool {
+	return len(c) > 0
 }
 
 // ScalingConfig represents the [cerebrium.scaling] section
@@ -123,15 +150,14 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 	if pc.Hardware.Memory != nil {
 		payload["memory"] = *pc.Hardware.Memory
 	}
-	if pc.Hardware.Compute != nil {
-		if len(pc.Hardware.ComputeFallbacks) > 0 {
-			all := append([]string{*pc.Hardware.Compute}, pc.Hardware.ComputeFallbacks...)
-			payload["compute"] = all
+	if pc.Hardware.Compute.IsSet() {
+		if len(pc.Hardware.Compute) == 1 {
+			payload["compute"] = pc.Hardware.Compute.Primary()
 		} else {
-			payload["compute"] = *pc.Hardware.Compute
+			payload["compute"] = []string(pc.Hardware.Compute)
 		}
 	}
-	if pc.Hardware.GPUCount != nil && pc.Hardware.Compute != nil && *pc.Hardware.Compute != "CPU" {
+	if pc.Hardware.GPUCount != nil && pc.Hardware.Compute.IsSet() && pc.Hardware.Compute.Primary() != "CPU" {
 		payload["gpuCount"] = *pc.Hardware.GPUCount
 	}
 	if pc.Hardware.Provider != nil {

--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -40,11 +40,9 @@ type HardwareConfig struct {
 	Region   *string      `mapstructure:"region" toml:"region,omitempty"`
 }
 
-// ComputeField accepts either a single value (`compute = "HOPPER_H100"`) or an
-// array (`compute = ["HOPPER_H100", "HOPPER_H200"]`). The first element is the
-// preferred compute type; the remainder are fallbacks the backend may schedule
-// onto when the primary is unavailable. Mirrors the backend's StringOrStrings
-// type so the CLI's in-memory model matches the wire format.
+// ComputeField holds the list of acceptable compute types. It accepts either a
+// single value (`compute = "HOPPER_H100"`) or an array
+// (`compute = ["HOPPER_H100", "HOPPER_H200"]`) in cerebrium.toml.
 type ComputeField []string
 
 // Primary returns the requested compute type, or "" when unset.
@@ -53,15 +51,6 @@ func (c ComputeField) Primary() string {
 		return ""
 	}
 	return c[0]
-}
-
-// Fallbacks returns the alternate compute types in priority order, or nil when
-// only a primary was configured.
-func (c ComputeField) Fallbacks() []string {
-	if len(c) <= 1 {
-		return nil
-	}
-	return c[1:]
 }
 
 // IsSet reports whether compute was configured in any form.
@@ -159,8 +148,7 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		payload["memory"] = *pc.Hardware.Memory
 	}
 	if pc.Hardware.Compute.IsSet() {
-		// The backend accepts either a string or a string[], so always send the
-		// slice and let it decide how to interpret primary vs. fallbacks.
+		// Always send the full list of compute types.
 		payload["compute"] = []string(pc.Hardware.Compute)
 	}
 	if pc.Hardware.GPUCount != nil && pc.Hardware.Compute.IsSet() && pc.Hardware.Compute.Primary() != "CPU" {

--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -28,7 +28,9 @@ type DeploymentConfig struct {
 type HardwareConfig struct {
 	CPU      *float64 `mapstructure:"cpu" toml:"cpu,omitempty"`
 	Memory   *float64 `mapstructure:"memory" toml:"memory,omitempty"`
-	Compute  *string  `mapstructure:"compute" toml:"compute,omitempty"`
+	ComputeRaw       interface{} `mapstructure:"compute" toml:"compute,omitempty"`
+	Compute          *string     `mapstructure:"-" toml:"-"`
+	ComputeFallbacks []string    `mapstructure:"-" toml:"-"`
 	GPUCount *int     `mapstructure:"gpu_count" toml:"gpu_count,omitempty"`
 	Provider *string  `mapstructure:"provider" toml:"provider,omitempty"`
 	Region   *string  `mapstructure:"region" toml:"region,omitempty"`
@@ -114,7 +116,12 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		payload["memory"] = *pc.Hardware.Memory
 	}
 	if pc.Hardware.Compute != nil {
-		payload["compute"] = *pc.Hardware.Compute
+		if len(pc.Hardware.ComputeFallbacks) > 0 {
+			all := append([]string{*pc.Hardware.Compute}, pc.Hardware.ComputeFallbacks...)
+			payload["compute"] = all
+		} else {
+			payload["compute"] = *pc.Hardware.Compute
+		}
 	}
 	if pc.Hardware.GPUCount != nil && pc.Hardware.Compute != nil && *pc.Hardware.Compute != "CPU" {
 		payload["gpuCount"] = *pc.Hardware.GPUCount
@@ -159,6 +166,9 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 	}
 	if pc.Scaling.LoadBalancingAlgorithm != nil {
 		payload["loadBalancingAlgorithm"] = *pc.Scaling.LoadBalancingAlgorithm
+	}
+	if pc.Scaling.ComputeTier != nil {
+		payload["computeTier"] = *pc.Scaling.ComputeTier
 	}
 
 	// Runtime configuration

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -50,16 +50,12 @@ func Load(configPath string) (*ProjectConfig, error) {
 
 	// Parse hardware section.
 	// The compute decode hook lets `compute` accept either a scalar or an array
-	// without leaking that polymorphism into the rest of the codebase. The
-	// default viper hooks are preserved so other slice/duration fields keep
-	// working.
+	// without leaking that polymorphism into the rest of the codebase. Hardware
+	// has no duration or comma-slice fields, so viper's default hooks aren't
+	// needed here.
 	if v.IsSet("cerebrium.hardware") {
 		if err := v.UnmarshalKey("cerebrium.hardware", &config.Hardware,
-			viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
-				mapstructure.StringToTimeDurationHookFunc(),
-				mapstructure.StringToSliceHookFunc(","),
-				computeFieldDecodeHook(),
-			)),
+			viper.DecodeHook(computeFieldDecodeHook()),
 		); err != nil {
 			return nil, fmt.Errorf("failed to parse hardware config: %w", err)
 		}

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -144,7 +144,7 @@ func Load(configPath string) (*ProjectConfig, error) {
 // rely on `IsSet() => Primary() != ""`.
 func computeFieldDecodeHook() mapstructure.DecodeHookFunc {
 	computeFieldType := reflect.TypeOf(ComputeField{})
-	return func(_ reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+	return func(_ reflect.Type, to reflect.Type, data any) (any, error) {
 		if to != computeFieldType {
 			return data, nil
 		}
@@ -154,7 +154,7 @@ func computeFieldDecodeHook() mapstructure.DecodeHookFunc {
 				return nil, fmt.Errorf("compute must not be empty")
 			}
 			return ComputeField{v}, nil
-		case []interface{}:
+		case []any:
 			if len(v) == 0 {
 				return nil, fmt.Errorf("compute array must not be empty")
 			}

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -116,6 +116,11 @@ func Load(configPath string) (*ProjectConfig, error) {
 		}
 	}
 
+	// Normalize compute: accepts string or array
+	if err := normalizeCompute(&config.Hardware); err != nil {
+		return nil, err
+	}
+
 	// Validate compute_tier before applying defaults
 	if config.Scaling.ComputeTier != nil {
 		tier := *config.Scaling.ComputeTier
@@ -128,6 +133,40 @@ func Load(configPath string) (*ProjectConfig, error) {
 	applyDefaults(&config)
 
 	return &config, nil
+}
+
+// normalizeCompute splits the polymorphic compute field (string or []string) into
+// a single primary value (Compute) plus optional fallbacks (ComputeFallbacks).
+// Viper decodes the TOML scalar/array into ComputeRaw as interface{}; this turns
+// it into typed fields the rest of the codebase can use without caring about the
+// input shape. Backend accepts either form under "compute" (see compute.StringOrStrings).
+func normalizeCompute(hw *HardwareConfig) error {
+	if hw.ComputeRaw == nil {
+		return nil
+	}
+	switch v := hw.ComputeRaw.(type) {
+	case string:
+		hw.Compute = &v
+	case []interface{}:
+		if len(v) == 0 {
+			return fmt.Errorf("compute array must not be empty")
+		}
+		first, ok := v[0].(string)
+		if !ok {
+			return fmt.Errorf("compute values must be strings")
+		}
+		hw.Compute = &first
+		for _, item := range v[1:] {
+			s, ok := item.(string)
+			if !ok {
+				return fmt.Errorf("compute values must be strings")
+			}
+			hw.ComputeFallbacks = append(hw.ComputeFallbacks, s)
+		}
+	default:
+		return fmt.Errorf("compute must be a string or array of strings")
+	}
+	return nil
 }
 
 // applyDefaults sets default values for CLI-only fields that weren't specified in the config.

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -3,7 +3,9 @@ package projectconfig
 import (
 	"fmt"
 	"os"
+	"reflect"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 )
 
@@ -46,9 +48,19 @@ func Load(configPath string) (*ProjectConfig, error) {
 		return nil, fmt.Errorf("failed to parse deployment config: %w", err)
 	}
 
-	// Parse hardware section
+	// Parse hardware section.
+	// The compute decode hook lets `compute` accept either a scalar or an array
+	// without leaking that polymorphism into the rest of the codebase. The
+	// default viper hooks are preserved so other slice/duration fields keep
+	// working.
 	if v.IsSet("cerebrium.hardware") {
-		if err := v.UnmarshalKey("cerebrium.hardware", &config.Hardware); err != nil {
+		if err := v.UnmarshalKey("cerebrium.hardware", &config.Hardware,
+			viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+				mapstructure.StringToTimeDurationHookFunc(),
+				mapstructure.StringToSliceHookFunc(","),
+				computeFieldDecodeHook(),
+			)),
+		); err != nil {
 			return nil, fmt.Errorf("failed to parse hardware config: %w", err)
 		}
 	}
@@ -116,11 +128,6 @@ func Load(configPath string) (*ProjectConfig, error) {
 		}
 	}
 
-	// Normalize compute: accepts string or array
-	if err := normalizeCompute(&config.Hardware); err != nil {
-		return nil, err
-	}
-
 	// Validate compute_tier before applying defaults
 	if config.Scaling.ComputeTier != nil {
 		tier := *config.Scaling.ComputeTier
@@ -135,38 +142,39 @@ func Load(configPath string) (*ProjectConfig, error) {
 	return &config, nil
 }
 
-// normalizeCompute splits the polymorphic compute field (string or []string) into
-// a single primary value (Compute) plus optional fallbacks (ComputeFallbacks).
-// Viper decodes the TOML scalar/array into ComputeRaw as interface{}; this turns
-// it into typed fields the rest of the codebase can use without caring about the
-// input shape. Backend accepts either form under "compute" (see compute.StringOrStrings).
-func normalizeCompute(hw *HardwareConfig) error {
-	if hw.ComputeRaw == nil {
-		return nil
-	}
-	switch v := hw.ComputeRaw.(type) {
-	case string:
-		hw.Compute = &v
-	case []interface{}:
-		if len(v) == 0 {
-			return fmt.Errorf("compute array must not be empty")
+// computeFieldDecodeHook teaches mapstructure how to read the polymorphic
+// `compute` field. Without it viper would refuse to decode a TOML scalar into
+// the ComputeField slice type. Rejects empty strings so downstream code can
+// rely on `IsSet() => Primary() != ""`.
+func computeFieldDecodeHook() mapstructure.DecodeHookFunc {
+	computeFieldType := reflect.TypeOf(ComputeField{})
+	return func(_ reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+		if to != computeFieldType {
+			return data, nil
 		}
-		first, ok := v[0].(string)
-		if !ok {
-			return fmt.Errorf("compute values must be strings")
-		}
-		hw.Compute = &first
-		for _, item := range v[1:] {
-			s, ok := item.(string)
-			if !ok {
-				return fmt.Errorf("compute values must be strings")
+		switch v := data.(type) {
+		case string:
+			if v == "" {
+				return nil, fmt.Errorf("compute must not be empty")
 			}
-			hw.ComputeFallbacks = append(hw.ComputeFallbacks, s)
+			return ComputeField{v}, nil
+		case []interface{}:
+			if len(v) == 0 {
+				return nil, fmt.Errorf("compute array must not be empty")
+			}
+			out := make(ComputeField, len(v))
+			for i, item := range v {
+				s, ok := item.(string)
+				if !ok || s == "" {
+					return nil, fmt.Errorf("compute values must be non-empty strings")
+				}
+				out[i] = s
+			}
+			return out, nil
+		default:
+			return nil, fmt.Errorf("compute must be a string or array of strings")
 		}
-	default:
-		return fmt.Errorf("compute must be a string or array of strings")
 	}
-	return nil
 }
 
 // applyDefaults sets default values for CLI-only fields that weren't specified in the config.

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -113,6 +113,11 @@ func Load(configPath string) (*ProjectConfig, error) {
 		}
 	}
 
+	// Normalize compute: accepts string or array
+	if err := normalizeCompute(&config.Hardware); err != nil {
+		return nil, err
+	}
+
 	// Validate compute_tier before applying defaults
 	if config.Scaling.ComputeTier != nil {
 		tier := *config.Scaling.ComputeTier
@@ -125,6 +130,35 @@ func Load(configPath string) (*ProjectConfig, error) {
 	applyDefaults(&config)
 
 	return &config, nil
+}
+
+func normalizeCompute(hw *HardwareConfig) error {
+	if hw.ComputeRaw == nil {
+		return nil
+	}
+	switch v := hw.ComputeRaw.(type) {
+	case string:
+		hw.Compute = &v
+	case []interface{}:
+		if len(v) == 0 {
+			return fmt.Errorf("compute array must not be empty")
+		}
+		first, ok := v[0].(string)
+		if !ok {
+			return fmt.Errorf("compute values must be strings")
+		}
+		hw.Compute = &first
+		for _, item := range v[1:] {
+			s, ok := item.(string)
+			if !ok {
+				return fmt.Errorf("compute values must be strings")
+			}
+			hw.ComputeFallbacks = append(hw.ComputeFallbacks, s)
+		}
+	default:
+		return fmt.Errorf("compute must be a string or array of strings")
+	}
+	return nil
 }
 
 // applyDefaults sets default values for fields that weren't specified in the config

--- a/pkg/projectconfig/loader_test.go
+++ b/pkg/projectconfig/loader_test.go
@@ -228,23 +228,21 @@ name = "test-app"
 		require.NoError(t, err)
 		assert.Equal(t, ComputeField{"HOPPER_H100"}, cfg.Hardware.Compute)
 		assert.Equal(t, "HOPPER_H100", cfg.Hardware.Compute.Primary())
-		assert.Nil(t, cfg.Hardware.Compute.Fallbacks())
 		assert.True(t, cfg.Hardware.Compute.IsSet())
 	})
 
-	t.Run("array form preserves order with fallbacks", func(t *testing.T) {
+	t.Run("array form preserves order", func(t *testing.T) {
 		cfg, err := Load(write(t, `compute = ["HOPPER_H100", "HOPPER_H200", "AMPERE_A100_80GB"]`))
 		require.NoError(t, err)
 		assert.Equal(t, ComputeField{"HOPPER_H100", "HOPPER_H200", "AMPERE_A100_80GB"}, cfg.Hardware.Compute)
 		assert.Equal(t, "HOPPER_H100", cfg.Hardware.Compute.Primary())
-		assert.Equal(t, []string{"HOPPER_H200", "AMPERE_A100_80GB"}, cfg.Hardware.Compute.Fallbacks())
 	})
 
 	t.Run("single-element array behaves like scalar", func(t *testing.T) {
 		cfg, err := Load(write(t, `compute = ["HOPPER_H100"]`))
 		require.NoError(t, err)
+		assert.Equal(t, ComputeField{"HOPPER_H100"}, cfg.Hardware.Compute)
 		assert.Equal(t, "HOPPER_H100", cfg.Hardware.Compute.Primary())
-		assert.Nil(t, cfg.Hardware.Compute.Fallbacks())
 	})
 
 	t.Run("missing compute leaves field empty", func(t *testing.T) {

--- a/pkg/projectconfig/loader_test.go
+++ b/pkg/projectconfig/loader_test.go
@@ -280,12 +280,12 @@ name = "test-app"
 }
 
 func TestToPayload_Compute(t *testing.T) {
-	t.Run("scalar form sends string", func(t *testing.T) {
+	t.Run("scalar form sends single-element array", func(t *testing.T) {
 		pc := &ProjectConfig{
 			Deployment: DeploymentConfig{Name: "x"},
 			Hardware:   HardwareConfig{Compute: ComputeField{"HOPPER_H100"}},
 		}
-		assert.Equal(t, "HOPPER_H100", pc.ToPayload()["compute"])
+		assert.Equal(t, []string{"HOPPER_H100"}, pc.ToPayload()["compute"])
 	})
 
 	t.Run("multi-element form sends array", func(t *testing.T) {

--- a/pkg/projectconfig/loader_test.go
+++ b/pkg/projectconfig/loader_test.go
@@ -208,3 +208,97 @@ name = "test-app"
 		assert.Contains(t, err.Error(), "'cerebrium' key not found")
 	})
 }
+
+func TestLoad_Compute(t *testing.T) {
+	const header = `[cerebrium.deployment]
+name = "test-app"
+
+[cerebrium.hardware]
+`
+
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "cerebrium.toml")
+		require.NoError(t, os.WriteFile(path, []byte(header+body), 0644))
+		return path
+	}
+
+	t.Run("scalar form populates primary only", func(t *testing.T) {
+		cfg, err := Load(write(t, `compute = "HOPPER_H100"`))
+		require.NoError(t, err)
+		assert.Equal(t, ComputeField{"HOPPER_H100"}, cfg.Hardware.Compute)
+		assert.Equal(t, "HOPPER_H100", cfg.Hardware.Compute.Primary())
+		assert.Nil(t, cfg.Hardware.Compute.Fallbacks())
+		assert.True(t, cfg.Hardware.Compute.IsSet())
+	})
+
+	t.Run("array form preserves order with fallbacks", func(t *testing.T) {
+		cfg, err := Load(write(t, `compute = ["HOPPER_H100", "HOPPER_H200", "AMPERE_A100_80GB"]`))
+		require.NoError(t, err)
+		assert.Equal(t, ComputeField{"HOPPER_H100", "HOPPER_H200", "AMPERE_A100_80GB"}, cfg.Hardware.Compute)
+		assert.Equal(t, "HOPPER_H100", cfg.Hardware.Compute.Primary())
+		assert.Equal(t, []string{"HOPPER_H200", "AMPERE_A100_80GB"}, cfg.Hardware.Compute.Fallbacks())
+	})
+
+	t.Run("single-element array behaves like scalar", func(t *testing.T) {
+		cfg, err := Load(write(t, `compute = ["HOPPER_H100"]`))
+		require.NoError(t, err)
+		assert.Equal(t, "HOPPER_H100", cfg.Hardware.Compute.Primary())
+		assert.Nil(t, cfg.Hardware.Compute.Fallbacks())
+	})
+
+	t.Run("missing compute leaves field empty", func(t *testing.T) {
+		cfg, err := Load(write(t, ``))
+		require.NoError(t, err)
+		assert.False(t, cfg.Hardware.Compute.IsSet())
+		assert.Equal(t, "", cfg.Hardware.Compute.Primary())
+	})
+
+	t.Run("empty array is rejected", func(t *testing.T) {
+		_, err := Load(write(t, `compute = []`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "compute array must not be empty")
+	})
+
+	t.Run("empty string is rejected", func(t *testing.T) {
+		_, err := Load(write(t, `compute = ""`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "compute must not be empty")
+	})
+
+	t.Run("non-string element is rejected", func(t *testing.T) {
+		_, err := Load(write(t, `compute = ["HOPPER_H100", 42]`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "compute values must be non-empty strings")
+	})
+
+	t.Run("wrong type is rejected", func(t *testing.T) {
+		_, err := Load(write(t, `compute = 42`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "compute must be a string or array of strings")
+	})
+}
+
+func TestToPayload_Compute(t *testing.T) {
+	t.Run("scalar form sends string", func(t *testing.T) {
+		pc := &ProjectConfig{
+			Deployment: DeploymentConfig{Name: "x"},
+			Hardware:   HardwareConfig{Compute: ComputeField{"HOPPER_H100"}},
+		}
+		assert.Equal(t, "HOPPER_H100", pc.ToPayload()["compute"])
+	})
+
+	t.Run("multi-element form sends array", func(t *testing.T) {
+		pc := &ProjectConfig{
+			Deployment: DeploymentConfig{Name: "x"},
+			Hardware:   HardwareConfig{Compute: ComputeField{"HOPPER_H100", "HOPPER_H200"}},
+		}
+		assert.Equal(t, []string{"HOPPER_H100", "HOPPER_H200"}, pc.ToPayload()["compute"])
+	})
+
+	t.Run("unset compute is omitted", func(t *testing.T) {
+		pc := &ProjectConfig{Deployment: DeploymentConfig{Name: "x"}}
+		_, present := pc.ToPayload()["compute"]
+		assert.False(t, present)
+	})
+}

--- a/pkg/projectconfig/validator.go
+++ b/pkg/projectconfig/validator.go
@@ -12,11 +12,6 @@ func Validate(config *ProjectConfig) error {
 		return fmt.Errorf("`deployment.name` is required in config file")
 	}
 
-	// Check for invalid provider
-	if config.Hardware.Provider != nil && *config.Hardware.Provider == "coreweave" {
-		return fmt.Errorf("cortex V4 does not support Coreweave. Please consider updating your app to AWS")
-	}
-
 	// Validate dockerfile path if specified
 	if config.CustomRuntime != nil && config.CustomRuntime.DockerfilePath != "" {
 		if _, err := os.Stat(config.CustomRuntime.DockerfilePath); os.IsNotExist(err) {

--- a/pkg/projectconfig/validator.go
+++ b/pkg/projectconfig/validator.go
@@ -12,6 +12,11 @@ func Validate(config *ProjectConfig) error {
 		return fmt.Errorf("`deployment.name` is required in config file")
 	}
 
+	// Check for invalid provider
+	if config.Hardware.Provider != nil && *config.Hardware.Provider == "coreweave" {
+		return fmt.Errorf("cortex V4 does not support Coreweave. Please consider updating your app to AWS")
+	}
+
 	// Validate dockerfile path if specified
 	if config.CustomRuntime != nil && config.CustomRuntime.DockerfilePath != "" {
 		if _, err := os.Stat(config.CustomRuntime.DockerfilePath); os.IsNotExist(err) {

--- a/pkg/projectconfig/validator.go
+++ b/pkg/projectconfig/validator.go
@@ -40,7 +40,7 @@ func Validate(config *ProjectConfig) error {
 	}
 
 	// Default gpu_count to 1 if compute is set but gpu_count is not
-	if config.Hardware.Compute != nil && *config.Hardware.Compute != "CPU" {
+	if config.Hardware.Compute.IsSet() && config.Hardware.Compute.Primary() != "CPU" {
 		if config.Hardware.GPUCount == nil {
 			defaultGPUCount := 1
 			config.Hardware.GPUCount = &defaultGPUCount


### PR DESCRIPTION
## Summary

`compute` now accepts either a single value or an array in `cerebrium.toml`:

```toml
compute = "HOPPER_H100"                                       # single
compute = ["HOPPER_H100", "HOPPER_H200", "AMPERE_A100_80GB"]  # multiple
```

It's just a list of acceptable compute types. The CLI keeps a single
polymorphic field internally and forwards the values on deploy.

## Changes

- `config.go`: `Compute` is a single `ComputeField` (`[]string`) with
  `Primary()` / `IsSet()` / `String()` helpers. The deploy payload always
  sends `compute` as an array.
- `loader.go`: parses either a string or an array into `ComputeField`,
  rejecting empty strings/arrays and non-string elements.
- Deploy summary shows a single `Compute:` row listing all values, and shows
  GPU count whenever it's set.
- `run.go`: the run path still sends a single compute value, as that endpoint
  takes one string.

## Backward compatible

- `compute = "HOPPER_H100"` (string) behaves exactly as before.
- Omitting `compute` is unchanged — a CPU deployment with the usual defaults.

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] Deployed to dev with array syntax
- [x] Deployed to dev with string syntax (backward compat)
- [x] Deployed to dev with no compute set (default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
