### PR TITLE
feat: add containers list command

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -383,6 +383,24 @@ func (c *client) GetApp(ctx context.Context, projectID, appID string) (*AppDetai
 	return &appDetails, nil
 }
 
+// ListContainers retrieves recent containers for an app from the v2 endpoint,
+// which is the same one the dashboard uses. The response includes pods that are
+// being torn down — distinguished by the IsTerminating field on each record.
+func (c *client) ListContainers(ctx context.Context, projectID, appID string) ([]Container, error) {
+	path := fmt.Sprintf("v2/projects/%s/apps/%s/containers", projectID, appID)
+	body, err := c.request(ctx, "GET", path, nil, true)
+	if err != nil {
+		return nil, err
+	}
+
+	containers := make([]Container, 0)
+	if err := json.Unmarshal(body, &containers); err != nil {
+		return nil, fmt.Errorf("failed to parse containers response: %w", err)
+	}
+
+	return containers, nil
+}
+
 // DeleteApp deletes a specific app
 func (c *client) DeleteApp(ctx context.Context, projectID, appID string) error {
 	path := fmt.Sprintf("v2/projects/%s/apps/%s", projectID, appID)

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -9,6 +9,7 @@ type Client interface {
 	UpdateApp(ctx context.Context, projectID, appID string, updates map[string]any) error
 	GetProjects(ctx context.Context) ([]Project, error)
 	GetRuns(ctx context.Context, projectID, appID string, asyncOnly bool) ([]Run, error)
+	ListContainers(ctx context.Context, projectID, appID string) ([]Container, error)
 	FetchAppLogs(ctx context.Context, projectID, appID string, opts AppLogOptions) (*AppLogsResponse, error)
 
 	// Deploy methods

--- a/internal/api/mock/client_gen.go
+++ b/internal/api/mock/client_gen.go
@@ -262,80 +262,6 @@ func (_c *MockClient_CreateApp_Call) RunAndReturn(run func(ctx context.Context, 
 	return _c
 }
 
-// CreatePartnerApp provides a mock function for the type MockClient
-func (_mock *MockClient) CreatePartnerApp(ctx context.Context, projectID string, payload map[string]any) (*api.CreateAppResponse, error) {
-	ret := _mock.Called(ctx, projectID, payload)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreatePartnerApp")
-	}
-
-	var r0 *api.CreateAppResponse
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]any) (*api.CreateAppResponse, error)); ok {
-		return returnFunc(ctx, projectID, payload)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]any) *api.CreateAppResponse); ok {
-		r0 = returnFunc(ctx, projectID, payload)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*api.CreateAppResponse)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, map[string]any) error); ok {
-		r1 = returnFunc(ctx, projectID, payload)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockClient_CreatePartnerApp_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreatePartnerApp'
-type MockClient_CreatePartnerApp_Call struct {
-	*mock.Call
-}
-
-// CreatePartnerApp is a helper method to define mock.On call
-//   - ctx context.Context
-//   - projectID string
-//   - payload map[string]any
-func (_e *MockClient_Expecter) CreatePartnerApp(ctx interface{}, projectID interface{}, payload interface{}) *MockClient_CreatePartnerApp_Call {
-	return &MockClient_CreatePartnerApp_Call{Call: _e.mock.On("CreatePartnerApp", ctx, projectID, payload)}
-}
-
-func (_c *MockClient_CreatePartnerApp_Call) Run(run func(ctx context.Context, projectID string, payload map[string]any)) *MockClient_CreatePartnerApp_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 map[string]any
-		if args[2] != nil {
-			arg2 = args[2].(map[string]any)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockClient_CreatePartnerApp_Call) Return(createAppResponse *api.CreateAppResponse, err error) *MockClient_CreatePartnerApp_Call {
-	_c.Call.Return(createAppResponse, err)
-	return _c
-}
-
-func (_c *MockClient_CreatePartnerApp_Call) RunAndReturn(run func(ctx context.Context, projectID string, payload map[string]any) (*api.CreateAppResponse, error)) *MockClient_CreatePartnerApp_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CreateBaseImage provides a mock function for the type MockClient
 func (_mock *MockClient) CreateBaseImage(ctx context.Context, projectID string, appID string, region string, payload api.BaseImagePayload) (string, error) {
 	ret := _mock.Called(ctx, projectID, appID, region, payload)
@@ -416,6 +342,80 @@ func (_c *MockClient_CreateBaseImage_Call) Return(s string, err error) *MockClie
 }
 
 func (_c *MockClient_CreateBaseImage_Call) RunAndReturn(run func(ctx context.Context, projectID string, appID string, region string, payload api.BaseImagePayload) (string, error)) *MockClient_CreateBaseImage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreatePartnerApp provides a mock function for the type MockClient
+func (_mock *MockClient) CreatePartnerApp(ctx context.Context, projectID string, payload map[string]any) (*api.CreateAppResponse, error) {
+	ret := _mock.Called(ctx, projectID, payload)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreatePartnerApp")
+	}
+
+	var r0 *api.CreateAppResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]any) (*api.CreateAppResponse, error)); ok {
+		return returnFunc(ctx, projectID, payload)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]any) *api.CreateAppResponse); ok {
+		r0 = returnFunc(ctx, projectID, payload)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.CreateAppResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, map[string]any) error); ok {
+		r1 = returnFunc(ctx, projectID, payload)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_CreatePartnerApp_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreatePartnerApp'
+type MockClient_CreatePartnerApp_Call struct {
+	*mock.Call
+}
+
+// CreatePartnerApp is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+//   - payload map[string]any
+func (_e *MockClient_Expecter) CreatePartnerApp(ctx interface{}, projectID interface{}, payload interface{}) *MockClient_CreatePartnerApp_Call {
+	return &MockClient_CreatePartnerApp_Call{Call: _e.mock.On("CreatePartnerApp", ctx, projectID, payload)}
+}
+
+func (_c *MockClient_CreatePartnerApp_Call) Run(run func(ctx context.Context, projectID string, payload map[string]any)) *MockClient_CreatePartnerApp_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 map[string]any
+		if args[2] != nil {
+			arg2 = args[2].(map[string]any)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_CreatePartnerApp_Call) Return(createAppResponse *api.CreateAppResponse, err error) *MockClient_CreatePartnerApp_Call {
+	_c.Call.Return(createAppResponse, err)
+	return _c
+}
+
+func (_c *MockClient_CreatePartnerApp_Call) RunAndReturn(run func(ctx context.Context, projectID string, payload map[string]any) (*api.CreateAppResponse, error)) *MockClient_CreatePartnerApp_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1191,13 +1191,16 @@ func (_c *MockClient_GetFileSize_Call) Run(run func(ctx context.Context, url str
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
 
-func (_c *MockClient_GetFileSize_Call) Return(size int64, err error) *MockClient_GetFileSize_Call {
-	_c.Call.Return(size, err)
+func (_c *MockClient_GetFileSize_Call) Return(n int64, err error) *MockClient_GetFileSize_Call {
+	_c.Call.Return(n, err)
 	return _c
 }
 
@@ -1514,32 +1517,78 @@ func (_c *MockClient_InitiateUpload_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
-// ListFiles provides a mock function for the type MockClient
-func (_mock *MockClient) ListFiles(ctx context.Context, projectID string, path string, region string) ([]api.FileInfo, error) {
-	ret := _mock.Called(ctx, projectID, path, region)
+// ListAppSecrets provides a mock function for the type MockClient
+func (_mock *MockClient) ListAppSecrets(ctx context.Context, projectID string, appID string) (map[string]string, error) {
+	ret := _mock.Called(ctx, projectID, appID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for ListFiles")
+		panic("no return value specified for ListAppSecrets")
 	}
 
-	var r0 []api.FileInfo
+	var r0 map[string]string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) ([]api.FileInfo, error)); ok {
-		return returnFunc(ctx, projectID, path, region)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]string, error)); ok {
+		return returnFunc(ctx, projectID, appID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) []api.FileInfo); ok {
-		r0 = returnFunc(ctx, projectID, path, region)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]string); ok {
+		r0 = returnFunc(ctx, projectID, appID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]api.FileInfo)
+			r0 = ret.Get(0).(map[string]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = returnFunc(ctx, projectID, path, region)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, projectID, appID)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
+}
+
+// MockClient_ListAppSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAppSecrets'
+type MockClient_ListAppSecrets_Call struct {
+	*mock.Call
+}
+
+// ListAppSecrets is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+//   - appID string
+func (_e *MockClient_Expecter) ListAppSecrets(ctx interface{}, projectID interface{}, appID interface{}) *MockClient_ListAppSecrets_Call {
+	return &MockClient_ListAppSecrets_Call{Call: _e.mock.On("ListAppSecrets", ctx, projectID, appID)}
+}
+
+func (_c *MockClient_ListAppSecrets_Call) Run(run func(ctx context.Context, projectID string, appID string)) *MockClient_ListAppSecrets_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ListAppSecrets_Call) Return(stringToString map[string]string, err error) *MockClient_ListAppSecrets_Call {
+	_c.Call.Return(stringToString, err)
+	return _c
+}
+
+func (_c *MockClient_ListAppSecrets_Call) RunAndReturn(run func(ctx context.Context, projectID string, appID string) (map[string]string, error)) *MockClient_ListAppSecrets_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // ListContainers provides a mock function for the type MockClient
@@ -1616,6 +1665,34 @@ func (_c *MockClient_ListContainers_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// ListFiles provides a mock function for the type MockClient
+func (_mock *MockClient) ListFiles(ctx context.Context, projectID string, path string, region string) ([]api.FileInfo, error) {
+	ret := _mock.Called(ctx, projectID, path, region)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListFiles")
+	}
+
+	var r0 []api.FileInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) ([]api.FileInfo, error)); ok {
+		return returnFunc(ctx, projectID, path, region)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) []api.FileInfo); ok {
+		r0 = returnFunc(ctx, projectID, path, region)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.FileInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = returnFunc(ctx, projectID, path, region)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 // MockClient_ListFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListFiles'
 type MockClient_ListFiles_Call struct {
 	*mock.Call
@@ -1664,6 +1741,74 @@ func (_c *MockClient_ListFiles_Call) Return(fileInfos []api.FileInfo, err error)
 }
 
 func (_c *MockClient_ListFiles_Call) RunAndReturn(run func(ctx context.Context, projectID string, path string, region string) ([]api.FileInfo, error)) *MockClient_ListFiles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListSecrets provides a mock function for the type MockClient
+func (_mock *MockClient) ListSecrets(ctx context.Context, projectID string) (map[string]string, error) {
+	ret := _mock.Called(ctx, projectID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListSecrets")
+	}
+
+	var r0 map[string]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]string, error)); ok {
+		return returnFunc(ctx, projectID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]string); ok {
+		r0 = returnFunc(ctx, projectID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, projectID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ListSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSecrets'
+type MockClient_ListSecrets_Call struct {
+	*mock.Call
+}
+
+// ListSecrets is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+func (_e *MockClient_Expecter) ListSecrets(ctx interface{}, projectID interface{}) *MockClient_ListSecrets_Call {
+	return &MockClient_ListSecrets_Call{Call: _e.mock.On("ListSecrets", ctx, projectID)}
+}
+
+func (_c *MockClient_ListSecrets_Call) Run(run func(ctx context.Context, projectID string)) *MockClient_ListSecrets_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ListSecrets_Call) Return(stringToString map[string]string, err error) *MockClient_ListSecrets_Call {
+	_c.Call.Return(stringToString, err)
+	return _c
+}
+
+func (_c *MockClient_ListSecrets_Call) RunAndReturn(run func(ctx context.Context, projectID string) (map[string]string, error)) *MockClient_ListSecrets_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1853,6 +1998,138 @@ func (_c *MockClient_UpdateApp_Call) RunAndReturn(run func(ctx context.Context, 
 	return _c
 }
 
+// UpdateAppSecrets provides a mock function for the type MockClient
+func (_mock *MockClient) UpdateAppSecrets(ctx context.Context, projectID string, appID string, secrets map[string]string) error {
+	ret := _mock.Called(ctx, projectID, appID, secrets)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateAppSecrets")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]string) error); ok {
+		r0 = returnFunc(ctx, projectID, appID, secrets)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockClient_UpdateAppSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAppSecrets'
+type MockClient_UpdateAppSecrets_Call struct {
+	*mock.Call
+}
+
+// UpdateAppSecrets is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+//   - appID string
+//   - secrets map[string]string
+func (_e *MockClient_Expecter) UpdateAppSecrets(ctx interface{}, projectID interface{}, appID interface{}, secrets interface{}) *MockClient_UpdateAppSecrets_Call {
+	return &MockClient_UpdateAppSecrets_Call{Call: _e.mock.On("UpdateAppSecrets", ctx, projectID, appID, secrets)}
+}
+
+func (_c *MockClient_UpdateAppSecrets_Call) Run(run func(ctx context.Context, projectID string, appID string, secrets map[string]string)) *MockClient_UpdateAppSecrets_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 map[string]string
+		if args[3] != nil {
+			arg3 = args[3].(map[string]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_UpdateAppSecrets_Call) Return(err error) *MockClient_UpdateAppSecrets_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockClient_UpdateAppSecrets_Call) RunAndReturn(run func(ctx context.Context, projectID string, appID string, secrets map[string]string) error) *MockClient_UpdateAppSecrets_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateSecrets provides a mock function for the type MockClient
+func (_mock *MockClient) UpdateSecrets(ctx context.Context, projectID string, secrets map[string]string) error {
+	ret := _mock.Called(ctx, projectID, secrets)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateSecrets")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]string) error); ok {
+		r0 = returnFunc(ctx, projectID, secrets)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockClient_UpdateSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateSecrets'
+type MockClient_UpdateSecrets_Call struct {
+	*mock.Call
+}
+
+// UpdateSecrets is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+//   - secrets map[string]string
+func (_e *MockClient_Expecter) UpdateSecrets(ctx interface{}, projectID interface{}, secrets interface{}) *MockClient_UpdateSecrets_Call {
+	return &MockClient_UpdateSecrets_Call{Call: _e.mock.On("UpdateSecrets", ctx, projectID, secrets)}
+}
+
+func (_c *MockClient_UpdateSecrets_Call) Run(run func(ctx context.Context, projectID string, secrets map[string]string)) *MockClient_UpdateSecrets_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 map[string]string
+		if args[2] != nil {
+			arg2 = args[2].(map[string]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_UpdateSecrets_Call) Return(err error) *MockClient_UpdateSecrets_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockClient_UpdateSecrets_Call) RunAndReturn(run func(ctx context.Context, projectID string, secrets map[string]string) error) *MockClient_UpdateSecrets_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UploadPart provides a mock function for the type MockClient
 func (_mock *MockClient) UploadPart(ctx context.Context, url string, data []byte) (string, error) {
 	ret := _mock.Called(ctx, url, data)
@@ -1984,280 +2261,6 @@ func (_c *MockClient_UploadZip_Call) Return(err error) *MockClient_UploadZip_Cal
 }
 
 func (_c *MockClient_UploadZip_Call) RunAndReturn(run func(ctx context.Context, uploadURL string, zipPath string) error) *MockClient_UploadZip_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListSecrets provides a mock function for the type MockClient
-func (_mock *MockClient) ListSecrets(ctx context.Context, projectID string) (map[string]string, error) {
-	ret := _mock.Called(ctx, projectID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListSecrets")
-	}
-
-	var r0 map[string]string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (map[string]string, error)); ok {
-		return returnFunc(ctx, projectID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) map[string]string); ok {
-		r0 = returnFunc(ctx, projectID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, projectID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockClient_ListSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSecrets'
-type MockClient_ListSecrets_Call struct {
-	*mock.Call
-}
-
-// ListSecrets is a helper method to define mock.On call
-//   - ctx context.Context
-//   - projectID string
-func (_e *MockClient_Expecter) ListSecrets(ctx interface{}, projectID interface{}) *MockClient_ListSecrets_Call {
-	return &MockClient_ListSecrets_Call{Call: _e.mock.On("ListSecrets", ctx, projectID)}
-}
-
-func (_c *MockClient_ListSecrets_Call) Run(run func(ctx context.Context, projectID string)) *MockClient_ListSecrets_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockClient_ListSecrets_Call) Return(secrets map[string]string, err error) *MockClient_ListSecrets_Call {
-	_c.Call.Return(secrets, err)
-	return _c
-}
-
-func (_c *MockClient_ListSecrets_Call) RunAndReturn(run func(ctx context.Context, projectID string) (map[string]string, error)) *MockClient_ListSecrets_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateSecrets provides a mock function for the type MockClient
-func (_mock *MockClient) UpdateSecrets(ctx context.Context, projectID string, secrets map[string]string) error {
-	ret := _mock.Called(ctx, projectID, secrets)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateSecrets")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, map[string]string) error); ok {
-		r0 = returnFunc(ctx, projectID, secrets)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockClient_UpdateSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateSecrets'
-type MockClient_UpdateSecrets_Call struct {
-	*mock.Call
-}
-
-// UpdateSecrets is a helper method to define mock.On call
-//   - ctx context.Context
-//   - projectID string
-//   - secrets map[string]string
-func (_e *MockClient_Expecter) UpdateSecrets(ctx interface{}, projectID interface{}, secrets interface{}) *MockClient_UpdateSecrets_Call {
-	return &MockClient_UpdateSecrets_Call{Call: _e.mock.On("UpdateSecrets", ctx, projectID, secrets)}
-}
-
-func (_c *MockClient_UpdateSecrets_Call) Run(run func(ctx context.Context, projectID string, secrets map[string]string)) *MockClient_UpdateSecrets_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 map[string]string
-		if args[2] != nil {
-			arg2 = args[2].(map[string]string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockClient_UpdateSecrets_Call) Return(err error) *MockClient_UpdateSecrets_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockClient_UpdateSecrets_Call) RunAndReturn(run func(ctx context.Context, projectID string, secrets map[string]string) error) *MockClient_UpdateSecrets_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListAppSecrets provides a mock function for the type MockClient
-func (_mock *MockClient) ListAppSecrets(ctx context.Context, projectID string, appID string) (map[string]string, error) {
-	ret := _mock.Called(ctx, projectID, appID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListAppSecrets")
-	}
-
-	var r0 map[string]string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (map[string]string, error)); ok {
-		return returnFunc(ctx, projectID, appID)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) map[string]string); ok {
-		r0 = returnFunc(ctx, projectID, appID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = returnFunc(ctx, projectID, appID)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockClient_ListAppSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAppSecrets'
-type MockClient_ListAppSecrets_Call struct {
-	*mock.Call
-}
-
-// ListAppSecrets is a helper method to define mock.On call
-//   - ctx context.Context
-//   - projectID string
-//   - appID string
-func (_e *MockClient_Expecter) ListAppSecrets(ctx interface{}, projectID interface{}, appID interface{}) *MockClient_ListAppSecrets_Call {
-	return &MockClient_ListAppSecrets_Call{Call: _e.mock.On("ListAppSecrets", ctx, projectID, appID)}
-}
-
-func (_c *MockClient_ListAppSecrets_Call) Run(run func(ctx context.Context, projectID string, appID string)) *MockClient_ListAppSecrets_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockClient_ListAppSecrets_Call) Return(secrets map[string]string, err error) *MockClient_ListAppSecrets_Call {
-	_c.Call.Return(secrets, err)
-	return _c
-}
-
-func (_c *MockClient_ListAppSecrets_Call) RunAndReturn(run func(ctx context.Context, projectID string, appID string) (map[string]string, error)) *MockClient_ListAppSecrets_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateAppSecrets provides a mock function for the type MockClient
-func (_mock *MockClient) UpdateAppSecrets(ctx context.Context, projectID string, appID string, secrets map[string]string) error {
-	ret := _mock.Called(ctx, projectID, appID, secrets)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateAppSecrets")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, map[string]string) error); ok {
-		r0 = returnFunc(ctx, projectID, appID, secrets)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockClient_UpdateAppSecrets_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateAppSecrets'
-type MockClient_UpdateAppSecrets_Call struct {
-	*mock.Call
-}
-
-// UpdateAppSecrets is a helper method to define mock.On call
-//   - ctx context.Context
-//   - projectID string
-//   - appID string
-//   - secrets map[string]string
-func (_e *MockClient_Expecter) UpdateAppSecrets(ctx interface{}, projectID interface{}, appID interface{}, secrets interface{}) *MockClient_UpdateAppSecrets_Call {
-	return &MockClient_UpdateAppSecrets_Call{Call: _e.mock.On("UpdateAppSecrets", ctx, projectID, appID, secrets)}
-}
-
-func (_c *MockClient_UpdateAppSecrets_Call) Run(run func(ctx context.Context, projectID string, appID string, secrets map[string]string)) *MockClient_UpdateAppSecrets_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 map[string]string
-		if args[3] != nil {
-			arg3 = args[3].(map[string]string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-			arg3,
-		)
-	})
-	return _c
-}
-
-func (_c *MockClient_UpdateAppSecrets_Call) Return(err error) *MockClient_UpdateAppSecrets_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockClient_UpdateAppSecrets_Call) RunAndReturn(run func(ctx context.Context, projectID string, appID string, secrets map[string]string) error) *MockClient_UpdateAppSecrets_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/api/mock/client_gen.go
+++ b/internal/api/mock/client_gen.go
@@ -1542,6 +1542,80 @@ func (_mock *MockClient) ListFiles(ctx context.Context, projectID string, path s
 	return r0, r1
 }
 
+// ListContainers provides a mock function for the type MockClient
+func (_mock *MockClient) ListContainers(ctx context.Context, projectID string, appID string) ([]api.Container, error) {
+	ret := _mock.Called(ctx, projectID, appID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListContainers")
+	}
+
+	var r0 []api.Container
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) ([]api.Container, error)); ok {
+		return returnFunc(ctx, projectID, appID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) []api.Container); ok {
+		r0 = returnFunc(ctx, projectID, appID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]api.Container)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, projectID, appID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_ListContainers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListContainers'
+type MockClient_ListContainers_Call struct {
+	*mock.Call
+}
+
+// ListContainers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+//   - appID string
+func (_e *MockClient_Expecter) ListContainers(ctx interface{}, projectID interface{}, appID interface{}) *MockClient_ListContainers_Call {
+	return &MockClient_ListContainers_Call{Call: _e.mock.On("ListContainers", ctx, projectID, appID)}
+}
+
+func (_c *MockClient_ListContainers_Call) Run(run func(ctx context.Context, projectID string, appID string)) *MockClient_ListContainers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_ListContainers_Call) Return(containers []api.Container, err error) *MockClient_ListContainers_Call {
+	_c.Call.Return(containers, err)
+	return _c
+}
+
+func (_c *MockClient_ListContainers_Call) RunAndReturn(run func(ctx context.Context, projectID string, appID string) ([]api.Container, error)) *MockClient_ListContainers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MockClient_ListFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListFiles'
 type MockClient_ListFiles_Call struct {
 	*mock.Call

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -358,6 +358,28 @@ func (r *Run) GetDisplayStatus() string {
 	}
 }
 
+// Container represents a recent container record for a Cerebrium app.
+// Mirrors the response from GET /v2/projects/{project_id}/apps/{app_id}/containers,
+// which is sourced from ClickHouse billing telemetry and includes pods that are
+// being torn down (flagged via IsTerminating).
+type Container struct {
+	AppID                         string    `json:"appId"`
+	ProjectID                     string    `json:"projectId"`
+	ContainerID                   string    `json:"containerId"`
+	ContainerState                string    `json:"containerState"` // RUNNING, PENDING, SUCCEEDED, etc.
+	Timestamp                     time.Time `json:"timestamp"`
+	ContainerStartTimestamp       time.Time `json:"containerStartTimestamp"`
+	ContainerTerminationTimestamp time.Time `json:"containerTerminationTimestamp"`
+	ContainerRunningTimeMs        int64     `json:"containerRunningTimeMs"`
+	ContainerRestartCount         int64     `json:"containerRestartCount"`
+	HostIP                        string    `json:"hostIp"`
+	ContainerIP                   string    `json:"containerIp"`
+	HardwareProvider              string    `json:"hardwareProvider"`
+	Region                        string    `json:"region"`
+	BuildID                       string    `json:"buildId"`
+	IsTerminating                 bool      `json:"isTerminating"`
+}
+
 // AppBuild represents a build for a Cerebrium application
 type AppBuild struct {
 	Id        string `json:"id"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -359,9 +359,6 @@ func (r *Run) GetDisplayStatus() string {
 }
 
 // Container represents a recent container record for a Cerebrium app.
-// Mirrors the response from GET /v2/projects/{project_id}/apps/{app_id}/containers,
-// which is sourced from ClickHouse billing telemetry and includes pods that are
-// being torn down (flagged via IsTerminating).
 type Container struct {
 	AppID                         string    `json:"appId"`
 	ProjectID                     string    `json:"projectId"`

--- a/internal/commands/containers/list.go
+++ b/internal/commands/containers/list.go
@@ -63,17 +63,18 @@ func runList(cmd *cobra.Command, appName string) error {
 		return nil
 	}
 
-	fmt.Printf("%-50s %-12s %-10s %s\n", "CONTAINER ID", "STATE", "RESTARTS", "REGION")
+	fmt.Printf("%-50s %-12s %-10s %-15s %s\n", "CONTAINER ID", "STATE", "RESTARTS", "REGION", "BUILD")
 	for _, c := range containers {
 		state := c.ContainerState
 		if c.IsTerminating {
 			state = "TERMINATING"
 		}
-		fmt.Printf("%-50s %-12s %-10d %s\n",
+		fmt.Printf("%-50s %-12s %-10d %-15s %s\n",
 			c.ContainerID,
 			state,
 			c.ContainerRestartCount,
 			c.Region,
+			c.BuildID,
 		)
 	}
 

--- a/internal/commands/containers/list.go
+++ b/internal/commands/containers/list.go
@@ -1,0 +1,90 @@
+package containers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cerebriumai/cerebrium/internal/api"
+	"github.com/cerebriumai/cerebrium/internal/ui"
+	"github.com/cerebriumai/cerebrium/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func newListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list APP_NAME",
+		Short: "List containers for an app and their states",
+		Long: `List the recent containers for an app along with their state, including any
+that are currently being torn down (shown as TERMINATING).
+
+Example:
+  cerebrium containers list my-app
+  cerebrium containers list p-abc12345-my-app`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(cmd, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runList(cmd *cobra.Command, appName string) error {
+	cmd.SilenceUsage = true
+
+	cfg, err := config.GetConfigFromContext(cmd)
+	if err != nil {
+		return ui.NewValidationError(fmt.Errorf("failed to get config: %w", err))
+	}
+
+	projectID, err := cfg.GetCurrentProject()
+	if err != nil {
+		return ui.NewValidationError(fmt.Errorf("no project selected: %w", err))
+	}
+
+	appID := normalizeAppID(projectID, appName)
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return ui.NewValidationError(fmt.Errorf("failed to create API client: %w", err))
+	}
+
+	spinner := ui.NewSimpleSpinner("Loading containers...")
+	spinner.Start()
+
+	containers, err := client.ListContainers(cmd.Context(), projectID, appID)
+	spinner.Stop()
+	if err != nil {
+		return ui.NewAPIError(err)
+	}
+
+	if len(containers) == 0 {
+		fmt.Printf("No containers found for app: %s\n", appName)
+		return nil
+	}
+
+	fmt.Printf("%-50s %-12s %-10s %s\n", "CONTAINER ID", "STATE", "RESTARTS", "REGION")
+	for _, c := range containers {
+		state := c.ContainerState
+		if c.IsTerminating {
+			state = "TERMINATING"
+		}
+		fmt.Printf("%-50s %-12s %-10d %s\n",
+			c.ContainerID,
+			state,
+			c.ContainerRestartCount,
+			c.Region,
+		)
+	}
+
+	return nil
+}
+
+// normalizeAppID ensures the app ID has the project ID prefix.
+func normalizeAppID(projectID, appName string) string {
+	expectedPrefix := projectID + "-"
+	if strings.HasPrefix(appName, expectedPrefix) {
+		return appName
+	}
+	return fmt.Sprintf("%s-%s", projectID, appName)
+}

--- a/internal/commands/containers/root.go
+++ b/internal/commands/containers/root.go
@@ -1,0 +1,17 @@
+package containers
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewContainersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "containers",
+		Short: "Manage and inspect app containers",
+		Long:  "Commands for inspecting the containers (knative pods) running your Cerebrium apps",
+	}
+
+	cmd.AddCommand(newListCmd())
+
+	return cmd
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -8,6 +8,7 @@ import (
 
 	appCmd "github.com/cerebriumai/cerebrium/internal/commands/apps"
 	configCmd "github.com/cerebriumai/cerebrium/internal/commands/config"
+	containersCmd "github.com/cerebriumai/cerebrium/internal/commands/containers"
 	filesCmd "github.com/cerebriumai/cerebrium/internal/commands/files"
 	projectCmd "github.com/cerebriumai/cerebrium/internal/commands/projects"
 	regionCmd "github.com/cerebriumai/cerebrium/internal/commands/region"
@@ -109,6 +110,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(NewRunCmd())
 	rootCmd.AddCommand(NewStatusCmd())
 	rootCmd.AddCommand(NewLogsCmd())
+	rootCmd.AddCommand(containersCmd.NewContainersCmd())
 	rootCmd.AddCommand(NewVersionCmd())
 	rootCmd.AddCommand(configCmd.NewConfigCmd())
 	rootCmd.AddCommand(appCmd.NewAppsCmd())


### PR DESCRIPTION
## Summary
- New `cerebrium containers list APP_NAME` command. Lists recent containers for an app along with their state.
- Reuses the dashboard's v2 endpoint (`/v2/projects/{p}/apps/{a}/containers`), so terminating pods are surfaced too — they show up as `TERMINATING`.
- `containers` is registered as a command group so we can hang future subcommands off it.

## Test plan
- [ ] `cerebrium containers list my-app` against a project with running containers
- [ ] Confirm a pod that is being torn down renders as `TERMINATING`
- [ ] `cerebrium containers list missing-app` returns the empty-state message cleanly
- [ ] `cerebrium containers --help` and `cerebrium containers list --help` render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)