### PR TITLE
fix: always include project config file in deployment zip

### DIFF
--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -122,6 +122,7 @@ func runDeploy(cmd *cobra.Command, opts deployOptions, disableConfirmation bool)
 	if len(testFiles) == 0 {
 		return ui.NewValidationError(fmt.Errorf("no files found matching include patterns. Please check your include/exclude patterns in cerebrium.toml"))
 	}
+	testFiles = files.EnsureFile(testFiles, opts.configFile)
 
 	// Warn about development folders
 	devFolders := files.DetectDevFolders(testFiles)
@@ -144,6 +145,7 @@ func runDeploy(cmd *cobra.Command, opts deployOptions, disableConfirmation bool)
 	model := uiCommands.NewDeployView(cmd.Context(), uiCommands.DeployConfig{
 		DisplayConfig:       displayOpts,
 		Config:              projectConfig,
+		ConfigPath:          opts.configFile,
 		ProjectID:           cfg.ProjectID,
 		Client:              client,
 		WSClient:            wsClient,

--- a/internal/files/include.go
+++ b/internal/files/include.go
@@ -3,10 +3,25 @@ package files
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
+
+// EnsureFile appends path to fileList if not already present, normalizing it
+// to the forward-slash, no-leading-"./" form produced by DetermineIncludes.
+// Returns the list unchanged if path is empty.
+func EnsureFile(fileList []string, path string) []string {
+	if path == "" {
+		return fileList
+	}
+	normalized := strings.TrimPrefix(filepath.ToSlash(path), "./")
+	if slices.Contains(fileList, normalized) {
+		return fileList
+	}
+	return append(fileList, normalized)
+}
 
 // DetermineIncludes walks the directory and returns files matching include/exclude patterns
 func DetermineIncludes(include, exclude []string) ([]string, error) {

--- a/internal/files/include_test.go
+++ b/internal/files/include_test.go
@@ -245,3 +245,56 @@ func TestDetermineIncludes_ExcludeSubdirectory(t *testing.T) {
 	assert.ElementsMatch(t, expected, result,
 		"Exclude patterns should work on subdirectories")
 }
+
+func TestEnsureFile(t *testing.T) {
+	tcs := []struct {
+		name     string
+		fileList []string
+		path     string
+		expected []string
+	}{
+		{
+			name:     "empty path is a no-op",
+			fileList: []string{"main.py"},
+			path:     "",
+			expected: []string{"main.py"},
+		},
+		{
+			name:     "appends when missing",
+			fileList: []string{"main.py"},
+			path:     "cerebrium.toml",
+			expected: []string{"main.py", "cerebrium.toml"},
+		},
+		{
+			name:     "dedups when already present",
+			fileList: []string{"main.py", "cerebrium.toml"},
+			path:     "cerebrium.toml",
+			expected: []string{"main.py", "cerebrium.toml"},
+		},
+		{
+			name:     "strips leading ./ before dedup",
+			fileList: []string{"main.py", "cerebrium.toml"},
+			path:     "./cerebrium.toml",
+			expected: []string{"main.py", "cerebrium.toml"},
+		},
+		{
+			name:     "appends custom config name",
+			fileList: []string{"main.py"},
+			path:     "./custom-config.toml",
+			expected: []string{"main.py", "custom-config.toml"},
+		},
+		{
+			name:     "appends dot-prefixed config",
+			fileList: []string{"main.py"},
+			path:     ".cerebrium.toml",
+			expected: []string{"main.py", ".cerebrium.toml"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := EnsureFile(tc.fileList, tc.path)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -51,10 +51,11 @@ const (
 type DeployConfig struct {
 	ui.DisplayConfig
 
-	Config    *projectconfig.ProjectConfig
-	ProjectID string
-	Client    api.Client
-	WSClient  wsapi.Client
+	Config     *projectconfig.ProjectConfig
+	ConfigPath string // Path to the project config file (always included in the zip)
+	ProjectID  string
+	Client     api.Client
+	WSClient   wsapi.Client
 
 	// Display config
 	DisableBuildLogs    bool
@@ -919,6 +920,10 @@ func (m *DeployView) loadFiles() tea.Msg {
 	if len(fileList) == 0 {
 		return ui.NewFileSystemError(fmt.Errorf("no files to upload. Please ensure you have files in your project"))
 	}
+
+	// Always include the project config file, even when include/exclude patterns
+	// would otherwise drop it (e.g. user-specified includes, custom config name, dot-prefixed name).
+	fileList = files.EnsureFile(fileList, m.conf.ConfigPath)
 
 	return filesLoadedMsg{fileList: fileList}
 }


### PR DESCRIPTION
## Summary
- The `cerebrium.toml` (or `--config-file` path) was only added to the deployment zip via the include patterns. It was silently dropped whenever the user specified their own `include` list that didn't match it, used a custom config name with custom includes, or used a dot-prefixed name (caught by the default `.*` exclude).
- Thread the config path through `DeployConfig.ConfigPath` and append it to the file list after `DetermineIncludes` via a new `files.EnsureFile` helper that normalizes (forward slashes, strips leading `./`) and dedupes.
- Apply `EnsureFile` to both the early-validation pass in `internal/commands/deploy.go` and the actual file load in `internal/ui/commands/deploy.go` so the dev-folder warning stays consistent with what actually ships.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — full suite passes
- [x] New `TestEnsureFile` covers empty path, dedup, `./` stripping, custom config name, dot-prefixed name
- [ ] Manual: `cerebrium deploy` with default `cerebrium.toml` and custom `include = ["main.py"]` — confirm `cerebrium.toml` is in the uploaded zip
- [ ] Manual: `cerebrium deploy --config-file ./custom.toml` with custom includes — confirm `custom.toml` is in the uploaded zip
- [ ] Manual: `cerebrium deploy --config-file ./.cerebrium.toml` — confirm dot-prefixed config is in the uploaded zip despite default `.*` exclude

🤖 Generated with [Claude Code](https://claude.com/claude-code)