### PR TITLE
fix: make esc cancel build to match advertised hint

### DIFF
--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -829,7 +829,7 @@ func (m *DeployView) onKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if msg.String() == tea.KeyCtrlC.String() {
+	if key := msg.String(); key == tea.KeyCtrlC.String() || key == tea.KeyEsc.String() {
 		// In detach mode, don't cancel the build - just exit cleanly
 		if m.conf.Detach {
 			m.err = ui.NewUserCancelledError()


### PR DESCRIPTION
## Summary
- The deploy view's help text reads `esc or ctrl+c: cancel build`, but the key handler at `internal/ui/commands/deploy.go:832` only matched `ctrl+c`. Pressing `esc` during a build did nothing.
- Updated the handler to also match `tea.KeyEsc` so the actual behavior matches what the hint already promises.

## Test plan
- [ ] Run `cerebrium deploy` in a TTY, start a build, press `esc` → build cancels cleanly
- [ ] Repeat with `ctrl+c` → still cancels (regression check)
- [ ] In `--detach` mode, `esc` exits without cancelling the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)