### PR TITLE
feat: remove client-side payload defaults so backend owns them

### DIFF
--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -1416,9 +1416,6 @@ func (m *DeployView) renderDeploymentSummary() string {
 		if m.conf.Config.Hardware.Region != nil {
 			hardwareItems = append(hardwareItems, fmt.Sprintf("Region: %s", *m.conf.Config.Hardware.Region))
 		}
-		if m.conf.Config.Hardware.Provider != nil {
-			hardwareItems = append(hardwareItems, fmt.Sprintf("Provider: %s", *m.conf.Config.Hardware.Provider))
-		}
 		if len(hardwareItems) > 0 {
 			formatSection("HARDWARE PARAMETERS", hardwareItems)
 		}
@@ -1566,9 +1563,6 @@ func (m *DeployView) renderDeploymentSummary() string {
 	}
 	if m.conf.Config.Hardware.Region != nil {
 		hardwareRows = append(hardwareRows, ui.TableRow{Label: "Region:", Value: *m.conf.Config.Hardware.Region})
-	}
-	if m.conf.Config.Hardware.Provider != nil {
-		hardwareRows = append(hardwareRows, ui.TableRow{Label: "Provider:", Value: *m.conf.Config.Hardware.Provider})
 	}
 	if len(hardwareRows) > 0 {
 		sections = append(sections, ui.TableSection{

--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -1357,8 +1357,9 @@ func renderRuntimeSpecificSettings(config *projectconfig.ProjectConfig) string {
 			settings = append(settings, fmt.Sprintf("Dockerfile: %s", config.CustomRuntime.DockerfilePath))
 		}
 
-		// Port is required for custom runtimes, always show it
-		settings = append(settings, fmt.Sprintf("Port: %d", config.CustomRuntime.Port))
+		if config.CustomRuntime.Port != 0 {
+			settings = append(settings, fmt.Sprintf("Port: %d", config.CustomRuntime.Port))
+		}
 
 		if len(config.CustomRuntime.Entrypoint) > 0 {
 			settings = append(settings, fmt.Sprintf("Entrypoint: %s", strings.Join(config.CustomRuntime.Entrypoint, " ")))

--- a/internal/ui/commands/login.go
+++ b/internal/ui/commands/login.go
@@ -370,13 +370,6 @@ func (m *LoginView) setProjectContext() tea.Msg {
 		}
 	}
 
-	// Set default region if not set
-	if m.conf.Config.DefaultRegion == "" {
-		m.conf.Config.DefaultRegion = "us-east-1"
-		//nolint:errcheck,gosec // Best effort save of default region, error not actionable
-		config.Save(m.conf.Config)
-	}
-
 	return projectSetMsg{message: message}
 }
 

--- a/internal/ui/commands/run.go
+++ b/internal/ui/commands/run.go
@@ -597,10 +597,10 @@ func (m *RunView) prepareRun() tea.Msg {
 		cfg, err := config.Load()
 		if err == nil && cfg.DefaultRegion != "" {
 			region = cfg.DefaultRegion
-		} else {
-			region = "us-east-1"
 		}
 	}
+	// If still empty, send through as-is — the backend resolves the run region
+	// (e.g. from the app's deployed region) when one isn't provided.
 
 	appName := ""
 	if m.conf.Config != nil && m.conf.Config.Deployment.Name != "" {

--- a/internal/ui/commands/testdata/deploy_full_config_confirmation.golden
+++ b/internal/ui/commands/testdata/deploy_full_config_confirmation.golden
@@ -7,7 +7,6 @@
 │  Memory:                       8 GB                                         │
 │  GPU Count:                    1                                            │
 │  Region:                       us-east-1                                    │
-│  Provider:                     aws                                          │
 │                                                                             │
 │  DEPLOYMENT PARAMETERS                                                      │
 │                                                                             │

--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -89,8 +89,12 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 
 	// Deployment fields
 	payload["name"] = pc.Deployment.Name
-	payload["pythonVersion"] = pc.Deployment.PythonVersion
-	payload["baseImage"] = pc.Deployment.DockerBaseImageURL
+	if pc.Deployment.PythonVersion != "" {
+		payload["pythonVersion"] = pc.Deployment.PythonVersion
+	}
+	if pc.Deployment.DockerBaseImageURL != "" {
+		payload["baseImage"] = pc.Deployment.DockerBaseImageURL
+	}
 	payload["include"] = pc.Deployment.Include
 	payload["exclude"] = pc.Deployment.Exclude
 	payload["shellCommands"] = pc.Deployment.ShellCommands
@@ -167,11 +171,7 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 	// Runtime configuration
 	if pc.CustomRuntime != nil && pc.PartnerService != nil {
 		// Both custom runtime and partner service
-		payload["entrypoint"] = pc.CustomRuntime.Entrypoint
-		payload["port"] = pc.CustomRuntime.Port
-		payload["healthcheckEndpoint"] = pc.CustomRuntime.HealthcheckEndpoint
-		payload["readycheckEndpoint"] = pc.CustomRuntime.ReadycheckEndpoint
-		payload["dockerfilePath"] = pc.CustomRuntime.DockerfilePath
+		addCustomRuntimePayload(payload, pc.CustomRuntime)
 		payload["partnerService"] = pc.PartnerService.Name
 		payload["runtime"] = pc.PartnerService.Name
 		if pc.PartnerService.ModelName != nil {
@@ -182,11 +182,7 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		}
 	} else if pc.CustomRuntime != nil {
 		// Custom runtime only
-		payload["entrypoint"] = pc.CustomRuntime.Entrypoint
-		payload["port"] = pc.CustomRuntime.Port
-		payload["healthcheckEndpoint"] = pc.CustomRuntime.HealthcheckEndpoint
-		payload["readycheckEndpoint"] = pc.CustomRuntime.ReadycheckEndpoint
-		payload["dockerfilePath"] = pc.CustomRuntime.DockerfilePath
+		addCustomRuntimePayload(payload, pc.CustomRuntime)
 		payload["runtime"] = "custom"
 	} else if pc.PartnerService != nil {
 		// Partner service only
@@ -207,4 +203,24 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 	}
 
 	return payload
+}
+
+// addCustomRuntimePayload only adds custom-runtime fields to the payload when the user
+// set them in cerebrium.toml. Unset fields are omitted so the backend can apply defaults.
+func addCustomRuntimePayload(payload map[string]any, cr *CustomRuntimeConfig) {
+	if len(cr.Entrypoint) > 0 {
+		payload["entrypoint"] = cr.Entrypoint
+	}
+	if cr.Port != 0 {
+		payload["port"] = cr.Port
+	}
+	if cr.HealthcheckEndpoint != "" {
+		payload["healthcheckEndpoint"] = cr.HealthcheckEndpoint
+	}
+	if cr.ReadycheckEndpoint != "" {
+		payload["readycheckEndpoint"] = cr.ReadycheckEndpoint
+	}
+	if cr.DockerfilePath != "" {
+		payload["dockerfilePath"] = cr.DockerfilePath
+	}
 }

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -7,20 +7,13 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Default values matching Python implementation
+// Default values for CLI-only file-packaging concerns.
+// All payload defaults (pythonVersion, baseImage, provider, region, scaling, auth,
+// entrypoint, port, healthcheck, etc.) are intentionally not set here — the backend
+// applies them when fields are absent from the request.
 var (
-	DefaultPythonVersion            = "3.11"
-	DefaultDockerBaseImageURL       = "debian:bookworm-slim"
-	DefaultInclude                  = []string{"./*", "main.py", "cerebrium.toml"}
-	DefaultExclude                  = []string{".*"}
-	DefaultDisableAuth              = true
-	DefaultEntrypoint               = []string{"uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"}
-	DefaultPort                     = 8000
-	DefaultHealthcheckEndpoint      = ""
-	DefaultReadycheckEndpoint       = ""
-	DefaultProvider                 = "aws"
-	DefaultEvaluationIntervalSeconds = 30
-	DefaultLoadBalancingAlgorithm   = "round-robin"
+	DefaultInclude = []string{"./*", "main.py", "cerebrium.toml"}
+	DefaultExclude = []string{".*"}
 )
 
 // Load reads and parses the cerebrium.toml configuration file
@@ -127,52 +120,15 @@ func Load(configPath string) (*ProjectConfig, error) {
 	return &config, nil
 }
 
-// applyDefaults sets default values for fields that weren't specified in the config
+// applyDefaults sets default values for CLI-only fields that weren't specified in the config.
+// Payload fields (pythonVersion, baseImage, provider, region, scaling, auth, entrypoint,
+// port, healthcheck, etc.) are deliberately left unset so the backend can apply its own defaults.
 func applyDefaults(config *ProjectConfig) {
-	// Apply deployment defaults
-	if config.Deployment.PythonVersion == "" {
-		config.Deployment.PythonVersion = DefaultPythonVersion
-	}
-	if config.Deployment.DockerBaseImageURL == "" {
-		config.Deployment.DockerBaseImageURL = DefaultDockerBaseImageURL
-	}
+	// File-packaging defaults — these aren't sent to the backend; they drive the deploy zip.
 	if len(config.Deployment.Include) == 0 {
 		config.Deployment.Include = DefaultInclude
 	}
 	if len(config.Deployment.Exclude) == 0 {
 		config.Deployment.Exclude = DefaultExclude
 	}
-	if config.Deployment.DisableAuth == nil {
-		disableAuth := DefaultDisableAuth
-		config.Deployment.DisableAuth = &disableAuth
-	}
-
-	// Apply hardware defaults
-	if config.Hardware.Provider == nil {
-		config.Hardware.Provider = &DefaultProvider
-	}
-
-	// Apply scaling defaults
-	if config.Scaling.EvaluationIntervalSeconds == nil {
-		config.Scaling.EvaluationIntervalSeconds = &DefaultEvaluationIntervalSeconds
-	}
-	if config.Scaling.LoadBalancingAlgorithm == nil {
-		config.Scaling.LoadBalancingAlgorithm = &DefaultLoadBalancingAlgorithm
-	}
-	// Apply custom runtime defaults
-	if config.CustomRuntime != nil {
-		if len(config.CustomRuntime.Entrypoint) == 0 {
-			config.CustomRuntime.Entrypoint = DefaultEntrypoint
-		}
-		if config.CustomRuntime.Port == 0 {
-			config.CustomRuntime.Port = DefaultPort
-		}
-		if config.CustomRuntime.HealthcheckEndpoint == "" {
-			config.CustomRuntime.HealthcheckEndpoint = DefaultHealthcheckEndpoint
-		}
-		if config.CustomRuntime.ReadycheckEndpoint == "" {
-			config.CustomRuntime.ReadycheckEndpoint = DefaultReadycheckEndpoint
-		}
-	}
-
 }

--- a/pkg/projectconfig/loader_test.go
+++ b/pkg/projectconfig/loader_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLoad(t *testing.T) {
-	t.Run("applies default DisableAuth when not specified", func(t *testing.T) {
+	t.Run("DisableAuth is nil when not specified (backend applies default)", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "cerebrium.toml")
 
@@ -22,8 +22,7 @@ name = "test-app"
 
 		config, err := Load(configPath)
 		require.NoError(t, err)
-		require.NotNil(t, config.Deployment.DisableAuth)
-		assert.Equal(t, true, *config.Deployment.DisableAuth)
+		assert.Nil(t, config.Deployment.DisableAuth)
 	})
 
 	t.Run("preserves explicit DisableAuth false", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Strip CLI-side defaults that were silently overriding backend defaults on every `create-app` call (provider=aws, pythonVersion=3.11, disableAuth=true, evaluationIntervalSeconds=30, loadBalancingAlgorithm=round-robin, custom-runtime entrypoint/port/healthcheck/readycheck).
- `applyDefaults()` is now limited to file-packaging concerns (`include`, `exclude`); `ToPayload()` omits unset `pythonVersion`/`baseImage`/custom-runtime fields so the backend can apply its own defaults.
- Drop the `us-east-1` fallback from `login` (default-region seeding) and `run`. When no region is set via `--region`, `[cerebrium.hardware].region`, or the user-config `default-region`, the empty value is passed through and the backend resolves it from the app's deployed region.

## Why
The hardcoded `provider=aws` is the trigger — it disabled smart provider routing on the backend. Several other CLI defaults also disagreed with backend defaults (e.g. `pythonVersion` 3.11 vs 3.10, `disableAuth` true vs false), and the CLI was always winning because it sent every field. Letting the backend own these means a single source of truth.

A companion backend PR aligns the backend defaults with the values the CLI was sending (3.11 / disableAuth=true / eval=30 / round-robin) and adds `app.Region`-based defaulting on the run-flow endpoints (`run_command`, `create_run_app`, `create_base_image`) so omitting `--region` works against existing apps.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] `cerebrium deploy` against a fresh `cerebrium.toml` — verify the request payload omits fields the user didn't set and the resulting app uses backend defaults
- [ ] `cerebrium deploy` with explicit `python_version`/`disable_auth`/etc. set in `cerebrium.toml` — verify those override correctly
- [ ] `cerebrium run` with no `--region` and no config-file region — confirm backend resolves the region from the existing app
- [ ] `cerebrium login` on a fresh machine — confirm `default-region` is no longer auto-seeded to `us-east-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)