### PR TITLE
fix: make CreateZip output reproducible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,3 +286,4 @@ func (m *MyView) Error() error {
 5. Use cmd.Context() and GetConfigFromContext()
 6. Never update golden files (humans only)
 7. Print SimpleOutput user output with fmt.Printf, debug with slog
+8. Repo is public — no internal infra, backend names, or runtime tech in code/comments/strings. Keep it generic ("the backend", "upstream").

--- a/internal/files/zipper.go
+++ b/internal/files/zipper.go
@@ -18,10 +18,9 @@ import (
 // can represent, and is the convention used by reproducible-build tooling
 // (Bazel, SOURCE_DATE_EPOCH consumers, etc.).
 //
-// Without this, the upload's S3 ETag becomes a per-deploy nonce because
-// every dependency file was stamped with time.Now() and every project file
-// inherited its filesystem mtime — fingerprint-based duplicate detection
-// in the backend was effectively dead.
+// Without this, dependency files stamped with time.Now() and project files
+// carrying their filesystem mtimes would make every zip differ even when
+// the input content is identical.
 var zipEpoch = time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // CreateZip creates a zip file containing all files in fileList with zip bomb protection

--- a/internal/files/zipper.go
+++ b/internal/files/zipper.go
@@ -6,10 +6,23 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/cerebriumai/cerebrium/pkg/projectconfig"
 )
+
+// zipEpoch pins every entry's modified time to a fixed value so that two
+// invocations of CreateZip on byte-identical content produce byte-identical
+// zips. 1980-01-01 is the MS-DOS date format minimum that the zip format
+// can represent, and is the convention used by reproducible-build tooling
+// (Bazel, SOURCE_DATE_EPOCH consumers, etc.).
+//
+// Without this, the upload's S3 ETag becomes a per-deploy nonce because
+// every dependency file was stamped with time.Now() and every project file
+// inherited its filesystem mtime — fingerprint-based duplicate detection
+// in the backend was effectively dead.
+var zipEpoch = time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // CreateZip creates a zip file containing all files in fileList with zip bomb protection
 func CreateZip(fileList []string, outputPath string, config *projectconfig.ProjectConfig) (int64, error) {
@@ -106,8 +119,8 @@ func addFileToZip(zipWriter *zip.Writer, filePath string) (int64, error) {
 	// Set the name to the relative path
 	header.Name = filepath.ToSlash(filePath)
 
-	// Set modified time to UTC
-	header.Modified = info.ModTime().UTC()
+	// Pin modified time to a fixed epoch for reproducible output (see zipEpoch).
+	header.Modified = zipEpoch
 
 	// Use deflate compression
 	header.Method = zip.Deflate
@@ -128,23 +141,32 @@ func addFileToZip(zipWriter *zip.Writer, filePath string) (int64, error) {
 	return info.Size(), nil
 }
 
-// AddDependencyFiles adds generated dependency files to the zip
+// AddDependencyFiles adds generated dependency files to the zip.
+//
+// Iteration order is sorted by filename so the output is reproducible —
+// Go's map iteration is randomized, so a plain `range` would write
+// dependency files into the zip in a different order on every invocation
+// even with byte-identical content.
 func AddDependencyFiles(zipWriter *zip.Writer, files map[string]string) error {
-	for filename, content := range files {
-		// Create zip header
+	filenames := make([]string, 0, len(files))
+	for filename := range files {
+		filenames = append(filenames, filename)
+	}
+	sort.Strings(filenames)
+
+	for _, filename := range filenames {
+		content := files[filename]
 		header := &zip.FileHeader{
 			Name:     filename,
 			Method:   zip.Deflate,
-			Modified: time.Now().UTC(),
+			Modified: zipEpoch,
 		}
 
-		// Create writer
 		writer, err := zipWriter.CreateHeader(header)
 		if err != nil {
 			return fmt.Errorf("failed to create header for %s: %w", filename, err)
 		}
 
-		// Write content
 		if _, err := writer.Write([]byte(content)); err != nil {
 			return fmt.Errorf("failed to write %s: %w", filename, err)
 		}

--- a/internal/files/zipper_test.go
+++ b/internal/files/zipper_test.go
@@ -1,0 +1,168 @@
+package files
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cerebriumai/cerebrium/pkg/projectconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateZip_Reproducible verifies the central guarantee of the deterministic
+// zip work: two CreateZip calls on byte-identical content produce byte-identical
+// zip output, which means the same content uploaded by two different users
+// (or by the same user twice) gets the same S3 ETag and therefore the same
+// fingerprint in the backend's app-build-fingerprints table.
+//
+// The test deliberately mutates each source file's mtime between the two zip
+// builds to prove that filesystem mtimes don't leak into the zip output.
+func TestCreateZip_Reproducible(t *testing.T) {
+	srcDir := t.TempDir()
+	mustWriteFile(t, filepath.Join(srcDir, "main.py"), "print('hello')\n")
+	mustWriteFile(t, filepath.Join(srcDir, "lib", "util.py"), "x = 1\n")
+	mustWriteFile(t, filepath.Join(srcDir, "cerebrium.toml"), "[cerebrium]\nname = \"test\"\n")
+
+	cfg := &projectconfig.ProjectConfig{
+		Dependencies: projectconfig.DependenciesConfig{
+			Pip: map[string]string{
+				"numpy":    "1.24.0",
+				"requests": ">=2.28.0",
+			},
+			Apt: map[string]string{
+				"ffmpeg": "latest",
+			},
+		},
+	}
+
+	hashA := buildZipHash(t, srcDir, cfg)
+
+	// Bump mtime on every source file so we'd be detected if mtime were
+	// leaking into the zip output.
+	bumped := time.Now().Add(2 * time.Hour)
+	mustWalkSetMtime(t, srcDir, bumped)
+
+	hashB := buildZipHash(t, srcDir, cfg)
+
+	assert.Equal(t, hashA, hashB,
+		"CreateZip output should be byte-identical across runs, even after touching source mtimes")
+}
+
+// TestCreateZip_PinsModifiedTimeToEpoch confirms every entry in the produced
+// zip has the fixed epoch as its modified time — both project files (which
+// previously inherited filesystem mtime) and dependency files (which previously
+// got time.Now()).
+func TestCreateZip_PinsModifiedTimeToEpoch(t *testing.T) {
+	srcDir := t.TempDir()
+	mustWriteFile(t, filepath.Join(srcDir, "main.py"), "x = 1\n")
+
+	cfg := &projectconfig.ProjectConfig{
+		Dependencies: projectconfig.DependenciesConfig{
+			Pip: map[string]string{"numpy": "1.24.0"},
+		},
+	}
+
+	zipPath := buildZip(t, srcDir, cfg)
+	r, err := zip.OpenReader(zipPath)
+	require.NoError(t, err)
+	defer r.Close()
+
+	require.NotEmpty(t, r.File, "zip should contain at least one entry")
+	for _, f := range r.File {
+		assert.True(t, f.Modified.Equal(zipEpoch),
+			"entry %q has Modified=%s, want %s", f.Name, f.Modified, zipEpoch)
+	}
+}
+
+// TestAddDependencyFiles_DeterministicOrder asserts dep files are written in
+// sorted order regardless of map iteration order. Run multiple times to make
+// the randomized map order surface if the sort were removed.
+func TestAddDependencyFiles_DeterministicOrder(t *testing.T) {
+	deps := map[string]string{
+		"requirements.txt":  "numpy==1.0.0\n",
+		"pkglist.txt":       "ffmpeg\n",
+		"conda_pkglist.txt": "pandas==2.0.0\n",
+	}
+	wantOrder := []string{"conda_pkglist.txt", "pkglist.txt", "requirements.txt"}
+
+	for i := 0; i < 10; i++ {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		require.NoError(t, AddDependencyFiles(zw, deps))
+		require.NoError(t, zw.Close())
+
+		r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		require.NoError(t, err)
+
+		got := make([]string, 0, len(r.File))
+		for _, f := range r.File {
+			got = append(got, f.Name)
+		}
+		assert.Equal(t, wantOrder, got, "iteration %d", i)
+	}
+}
+
+func buildZipHash(t *testing.T, srcDir string, cfg *projectconfig.ProjectConfig) string {
+	t.Helper()
+	zipPath := buildZip(t, srcDir, cfg)
+	f, err := os.Open(zipPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	h := md5.New()
+	_, err = io.Copy(h, f)
+	require.NoError(t, err)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func buildZip(t *testing.T, srcDir string, cfg *projectconfig.ProjectConfig) string {
+	t.Helper()
+
+	prevWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(srcDir))
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	fileList, err := DetermineIncludes([]string{"**/*"}, nil)
+	require.NoError(t, err)
+	// Sort to match what the deploy command does in practice and keep this
+	// test from depending on filepath.Walk's (already deterministic) order.
+	sortStrings(fileList)
+
+	zipPath := filepath.Join(t.TempDir(), "out.zip")
+	_, err = CreateZip(fileList, zipPath, cfg)
+	require.NoError(t, err)
+	return zipPath
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func mustWalkSetMtime(t *testing.T, root string, ts time.Time) {
+	t.Helper()
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		return os.Chtimes(path, ts, ts)
+	}))
+}
+
+func sortStrings(s []string) {
+	// tiny inline sort to keep the test self-contained.
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/internal/files/zipper_test.go
+++ b/internal/files/zipper_test.go
@@ -16,11 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCreateZip_Reproducible verifies the central guarantee of the deterministic
-// zip work: two CreateZip calls on byte-identical content produce byte-identical
-// zip output, which means the same content uploaded by two different users
-// (or by the same user twice) gets the same S3 ETag and therefore the same
-// fingerprint in the backend's app-build-fingerprints table.
+// TestCreateZip_Reproducible verifies that two CreateZip calls on byte-identical
+// content produce byte-identical zip output.
 //
 // The test deliberately mutates each source file's mtime between the two zip
 // builds to prove that filesystem mtimes don't leak into the zip output.


### PR DESCRIPTION
## Summary
The deploy zip we upload to S3 was being stamped with timestamps that change every run, so its S3 ETag — used by the dashboard backend as each build's \"upload hash\" — was effectively a per-deploy nonce. This breaks anything keying off content identity (cache reuse, idempotency checks, the new app-build-fingerprints duplicate detection in dashboard-backend).

Three causes in \`internal/files/zipper.go\`:

| Cause | Effect |
|---|---|
| \`addFileToZip\` set \`header.Modified = info.ModTime().UTC()\` | Anything that touches a file's mtime (\`git checkout\`, \`cp -r\`, editor auto-save, formatter, CI clone) bumped the hash. |
| \`AddDependencyFiles\` set \`header.Modified = time.Now().UTC()\` per dep file | Back-to-back deploys with byte-identical content produced different zips. |
| \`AddDependencyFiles\` iterated \`range files\` over a \`map[string]string\` | Go map iteration is randomized → dep file order in the zip differed across runs from the same input. |

## Fix
- Pin every entry's \`Modified\` to a fixed \`zipEpoch\` constant (1980-01-01, the zip-format minimum used by Bazel and SOURCE_DATE_EPOCH consumers).
- Sort dep file names before iterating in \`AddDependencyFiles\`.
- \`filepath.Walk\` is already lexical — no change needed for project files.

After this, two \`CreateZip\` calls on byte-identical input produce byte-identical zip output, the upload's S3 ETag becomes content-derived, and downstream content-hash signals start working.

## Test plan
- [x] \`TestCreateZip_Reproducible\` — builds the zip, mutates every source file's mtime by 2h, builds again, asserts MD5 of the two zips match
- [x] \`TestCreateZip_PinsModifiedTimeToEpoch\` — opens the produced zip and asserts every entry's \`Modified\` equals \`zipEpoch\`
- [x] \`TestAddDependencyFiles_DeterministicOrder\` — runs 10 iterations to surface the randomized map-iteration bug if the sort were removed
- [x] \`go test ./...\` clean across the whole repo

## Notes
- 1980-01-01 is intentional — earlier dates can't be represented in the MS-DOS date format that the zip spec uses, so something like \`time.Time{}\` (year 1) silently coerces in \`archive/zip\`.
- This does mean unzipped files now show 1980-01-01 in their mtime, which is the standard tradeoff for reproducible archives. \`unzip\` users will see this; build pipelines that look at mtime won't (they look at the file content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)