### PR TITLE
fix: deb download URL uses wrong filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ sudo mv cerebrium /usr/local/bin/
 # For ARM64, use: cerebrium_cli_linux_arm64.tar.gz
 
 # Or install via package manager (Ubuntu/Debian)
-wget https://github.com/CerebriumAI/cerebrium/releases/latest/download/cerebrium_linux_amd64.deb
-sudo dpkg -i cerebrium_linux_amd64.deb
+# Download the .deb for your architecture from the releases page:
+# https://github.com/CerebriumAI/cerebrium/releases/latest
+sudo dpkg -i cerebrium_*_linux_amd64.deb
 ```
 
 ### Windows


### PR DESCRIPTION
## Summary
The Ubuntu/Debian install snippet uses a static filename `cerebrium_linux_amd64.deb` in the wget URL, but release assets are named with the version number (e.g. `cerebrium_2.3.0_linux_amd64.deb`). The `/releases/latest/download/cerebrium_linux_amd64.deb` URL 404s. Updated the section to direct users to the releases page to grab the correct versioned file.

## How to reproduce
1. Copy the wget command from the README Direct Download section.
2. Run it — you get a 404 because `cerebrium_linux_amd64.deb` doesn't exist as a release asset (assets are versioned like `cerebrium_2.3.0_linux_amd64.deb`).

## Test plan
- Visit https://github.com/CerebriumAI/cerebrium/releases/latest and confirm the .deb assets are versioned.
- Follow the updated instructions to download and install the .deb successfully.