### PR TITLE
feat: forward container_runtime from cerebrium.toml to backend

### DIFF
--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -8,6 +8,10 @@ type ProjectConfig struct {
 	Dependencies   DependenciesConfig    `mapstructure:"dependencies" toml:"dependencies"`
 	CustomRuntime  *CustomRuntimeConfig  `mapstructure:"custom" toml:"runtime,omitempty"`
 	PartnerService *PartnerServiceConfig `mapstructure:"partner" toml:"partner,omitempty"`
+
+	// ContainerRuntime selects the sandbox runtime ("v1" runc / "v2" gvisor).
+	// Read from [cerebrium.runtime] container_runtime in cerebrium.toml.
+	ContainerRuntime *string `toml:"-"`
 }
 
 // DeploymentConfig represents the [cerebrium.deployment] section
@@ -166,6 +170,10 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 	}
 	if pc.Scaling.ComputeTier != nil {
 		payload["computeTier"] = *pc.Scaling.ComputeTier
+	}
+
+	if pc.ContainerRuntime != nil {
+		payload["containerRuntime"] = *pc.ContainerRuntime
 	}
 
 	// Runtime configuration

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -76,6 +76,16 @@ func Load(configPath string) (*ProjectConfig, error) {
 		config.CustomRuntime = &customRuntime
 	}
 
+	// Parse container_runtime scalar from [cerebrium.runtime].
+	// Coexists with [cerebrium.runtime.custom] / [cerebrium.runtime.<partner>] sub-tables.
+	if v.IsSet("cerebrium.runtime.container_runtime") {
+		cr := v.GetString("cerebrium.runtime.container_runtime")
+		if cr != "v1" && cr != "v2" {
+			return nil, fmt.Errorf("invalid container_runtime %q: must be \"v1\" or \"v2\"", cr)
+		}
+		config.ContainerRuntime = &cr
+	}
+
 	// Parse partner service sections (deepgram, rime, etc.)
 	partnerNames := []string{"deepgram", "rime"}
 	for _, partner := range partnerNames {

--- a/pkg/projectconfig/loader_test.go
+++ b/pkg/projectconfig/loader_test.go
@@ -117,6 +117,82 @@ compute_tier = "bogus"
 		assert.Contains(t, err.Error(), "invalid compute_tier")
 	})
 
+	t.Run("container_runtime is nil when not specified", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "cerebrium.toml")
+
+		content := `[cerebrium.deployment]
+name = "test-app"
+`
+		err := os.WriteFile(configPath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		config, err := Load(configPath)
+		require.NoError(t, err)
+		assert.Nil(t, config.ContainerRuntime)
+	})
+
+	t.Run("preserves explicit container_runtime v2", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "cerebrium.toml")
+
+		content := `[cerebrium.deployment]
+name = "test-app"
+
+[cerebrium.runtime]
+container_runtime = "v2"
+`
+		err := os.WriteFile(configPath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		config, err := Load(configPath)
+		require.NoError(t, err)
+		require.NotNil(t, config.ContainerRuntime)
+		assert.Equal(t, "v2", *config.ContainerRuntime)
+	})
+
+	t.Run("container_runtime coexists with custom runtime sub-table", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "cerebrium.toml")
+
+		content := `[cerebrium.deployment]
+name = "test-app"
+
+[cerebrium.runtime]
+container_runtime = "v2"
+
+[cerebrium.runtime.custom]
+port = 9000
+`
+		err := os.WriteFile(configPath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		config, err := Load(configPath)
+		require.NoError(t, err)
+		require.NotNil(t, config.ContainerRuntime)
+		assert.Equal(t, "v2", *config.ContainerRuntime)
+		require.NotNil(t, config.CustomRuntime)
+		assert.Equal(t, 9000, config.CustomRuntime.Port)
+	})
+
+	t.Run("returns error for invalid container_runtime", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "cerebrium.toml")
+
+		content := `[cerebrium.deployment]
+name = "test-app"
+
+[cerebrium.runtime]
+container_runtime = "v3"
+`
+		err := os.WriteFile(configPath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		_, err = Load(configPath)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid container_runtime")
+	})
+
 	t.Run("returns error when cerebrium key missing", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "cerebrium.toml")


### PR DESCRIPTION
## Summary

The CLI silently dropped `container_runtime` from `cerebrium.toml`, which is the knob users have to opt apps into an alternate runtime. The `ProjectConfig` struct had no field for it, `loader.go` only handled the `cerebrium.runtime.{custom,deepgram,rime}` sub-tables, and `ToPayload()` never emitted `containerRuntime` in the create-app payload. With the field missing from the deploy payload, the backend cannot honor the user's runtime selection, so apps that opt in silently fall back to the default.

`git log -S "container_runtime"` on this repo returns zero hits since the Go rewrite — the field was never ported from the Python CLI. Pair this with #72 ("remove client-side payload defaults so backend owns them"): the backend is now authoritative for defaults, so an unsent field cannot be set any other way from a fresh deploy.

## Changes

- `pkg/projectconfig/config.go`: add `ContainerRuntime *string` to `ProjectConfig` and emit `payload["containerRuntime"]` in `ToPayload()` when set
- `pkg/projectconfig/loader.go`: read `cerebrium.runtime.container_runtime` (coexists with `[cerebrium.runtime.custom]` and partner sub-tables), validate against `{v1, v2}` matching the backend's accepted values
- `pkg/projectconfig/loader_test.go`: cover present / absent / coexists-with-custom-runtime / invalid cases

## Test plan

- [x] `go test ./pkg/projectconfig/...` — all loader cases pass
- [x] `go test ./...` — full suite green
- [ ] Deploy a test app with `container_runtime = "v2"` and confirm the backend receives the field in the create-app payload
