### PR TITLE
chore: bump GitHub Actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## What

Bump the remaining GitHub Actions that still run on Node.js 20:

| File | Action | Before → After |
|------|--------|------|
| `release.yml` | `actions/setup-python` | `v5` → `v6` |
| `pypi-publish.yml` | `actions/setup-python` | `v5` → `v6` |
| `pypi-publish.yml` | `actions/checkout` | `v4` → `v5` |

## Why

Node.js 20 actions are deprecated. Actions will be forced to run on Node.js 24 by default starting June 16th, 2026, and Node.js 20 is removed from runners on September 16th, 2026. `setup-python@v6` and `checkout@v5` run on Node.js 24.

The remaining actions (`checkout@v5`, `setup-go@v6`, `golangci-lint-action@v8`, `goreleaser-action@v6`) were already current. Both new versions are drop-in compatible with the existing `with:` inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)