### PR TITLE
feat(deploy): upload raw cerebrium.toml as cerebrium_toml

### DIFF
--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -1018,6 +1018,11 @@ func (m *DeployView) createApp() tea.Msg {
 	payload["disableBuildLogs"] = m.conf.DisableBuildLogs
 	payload["cliVersion"] = version.Version
 
+	// Upload the raw cerebrium.toml so the backend can parse config server-side.
+	if m.conf.Config.RawTOML != "" {
+		payload["cerebrium_toml"] = m.conf.Config.RawTOML
+	}
+
 	// Include Docker auth if available for private registry support
 	baseImage := m.conf.Config.Deployment.DockerBaseImageURL
 	dockerAuth, err := auth.GetDockerAuth()

--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -11,7 +11,7 @@ type ProjectConfig struct {
 	CustomRuntime  *CustomRuntimeConfig  `mapstructure:"custom" toml:"runtime,omitempty"`
 	PartnerService *PartnerServiceConfig `mapstructure:"partner" toml:"partner,omitempty"`
 
-	// ContainerRuntime selects the runtime variant for the app.
+	// ContainerRuntime selects the sandbox runtime ("v1" runc / "v2" gvisor).
 	// Read from [cerebrium.runtime] container_runtime in cerebrium.toml.
 	ContainerRuntime *string `toml:"-"`
 }

--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -14,6 +14,10 @@ type ProjectConfig struct {
 	// ContainerRuntime selects the sandbox runtime ("v1" runc / "v2" gvisor).
 	// Read from [cerebrium.runtime] container_runtime in cerebrium.toml.
 	ContainerRuntime *string `toml:"-"`
+
+	// RawTOML is the verbatim cerebrium.toml content, captured at load time and
+	// uploaded so the backend can parse config server-side.
+	RawTOML string `toml:"-" mapstructure:"-"`
 }
 
 // DeploymentConfig represents the [cerebrium.deployment] section

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -1,6 +1,7 @@
 package projectconfig
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"reflect"
@@ -25,13 +26,17 @@ func Load(configPath string) (*ProjectConfig, error) {
 		return nil, fmt.Errorf("config file not found: %s. Please run `cerebrium init` to create one", configPath)
 	}
 
-	// Create new viper instance for project config
-	v := viper.New()
-	v.SetConfigFile(configPath)
-	v.SetConfigType("toml")
+	// Read the raw file once so we can both parse it and retain the verbatim content
+	// (the backend parses the raw toml server-side; see config.RawTOML below).
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
 
-	// Read the config file
-	if err := v.ReadInConfig(); err != nil {
+	// Create new viper instance for project config, parsing from the bytes we just read
+	v := viper.New()
+	v.SetConfigType("toml")
+	if err := v.ReadConfig(bytes.NewReader(content)); err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
@@ -134,6 +139,9 @@ func Load(configPath string) (*ProjectConfig, error) {
 
 	// Apply defaults for missing fields
 	applyDefaults(&config)
+
+	// Retain the verbatim toml so the deploy payload can upload it for server-side parsing.
+	config.RawTOML = string(content)
 
 	return &config, nil
 }

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -28,7 +28,7 @@ func Load(configPath string) (*ProjectConfig, error) {
 
 	// Read the raw file once so we can both parse it and retain the verbatim content
 	// (the backend parses the raw toml server-side; see config.RawTOML below).
-	content, err := os.ReadFile(configPath)
+	content, err := os.ReadFile(configPath) //nolint:gosec // File path from user's project configuration
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}


### PR DESCRIPTION
## What

The CLI now uploads the verbatim `cerebrium.toml` to the backend as a new payload field `cerebrium_toml`, alongside the existing structured `ToPayload()` map.

## Why

We're moving toward the backend parsing the raw `cerebrium.toml` server-side, so that **new config fields no longer require a CLI release** that users must install. This is the first, purely-additive CLI step; the backend will start consuming `cerebrium_toml` in a follow-up.

## How

- `ProjectConfig.RawTOML` holds the verbatim file content (tagged `toml:"-" mapstructure:"-"`).
- `projectconfig.Load()` now reads the file once itself and feeds the bytes to viper via `ReadConfig(bytes.NewReader(...))` (instead of `SetConfigFile`/`ReadInConfig`), retaining the raw text rather than re-reading it at upload time. Parsing behaviour is unchanged.
- `createApp()` sets `payload["cerebrium_toml"] = m.conf.Config.RawTOML`. Since the same payload feeds both `CreateApp` and `CreatePartnerApp`, both deploy paths get the field.

## Backward compatibility

Additive only — the backend continues to work off the structured payload; `cerebrium_toml` just rides along until the backend opts in.

## Testing

- `go build ./...` ✓
- `go test ./pkg/projectconfig/...` ✓ (existing `Load` tests green; `RawTOML` now populated)
- `go test ./internal/ui/commands/...` ✓ (no golden changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)