### PR TITLE
docs(files): document --region global for cp/download/ls/rm

### DIFF
--- a/internal/commands/files/cp.go
+++ b/internal/commands/files/cp.go
@@ -25,7 +25,8 @@ Examples:
   cerebrium cp local_file.txt              # Upload to /local_file.txt
   cerebrium cp local_file.txt remote.txt   # Upload to /remote.txt
   cerebrium cp local_dir/ remote_dir/      # Upload directory
-  cerebrium cp file.txt --region us-west-2 # Upload to specific region`,
+  cerebrium cp file.txt --region us-west-2 # Upload to specific region
+  cerebrium cp file.txt --region global    # Upload to global storage`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCp(cmd, args, region)

--- a/internal/commands/files/download.go
+++ b/internal/commands/files/download.go
@@ -24,7 +24,8 @@ func NewDownloadCmd() *cobra.Command {
 Examples:
   cerebrium download remote_file.txt                  # Download to ./remote_file.txt
   cerebrium download remote.txt local.txt             # Download to ./local.txt
-  cerebrium download file.txt --region us-west-2      # Download from specific region`,
+  cerebrium download file.txt --region us-west-2      # Download from specific region
+  cerebrium download file.txt --region global         # Download from global storage`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDownload(cmd, args, region)

--- a/internal/commands/files/ls.go
+++ b/internal/commands/files/ls.go
@@ -22,7 +22,8 @@ func NewLsCmd() *cobra.Command {
 Examples:
   cerebrium ls                    # List all files in the root directory
   cerebrium ls sub_folder/        # List all files in a specific directory
-  cerebrium ls --region us-west-2 # List files in a specific region`,
+  cerebrium ls --region us-west-2 # List files in a specific region
+  cerebrium ls --region global    # List files in global storage`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLs(cmd, args, region)

--- a/internal/commands/files/rm.go
+++ b/internal/commands/files/rm.go
@@ -23,7 +23,8 @@ Examples:
   cerebrium rm /file_name.txt              # Remove a specific file
   cerebrium rm /sub_folder/file_name.txt   # Remove file in subdirectory
   cerebrium rm /sub_folder/                # Remove directory (must end with /)
-  cerebrium rm --region us-west-2 /file    # Remove from specific region`,
+  cerebrium rm --region us-west-2 /file    # Remove from specific region
+  cerebrium rm --region global /file       # Remove from global storage`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRm(cmd, args, region)


### PR DESCRIPTION
## Summary

- Adds a \`--region global\` usage example to the \`Long\` description of \`cp\`, \`download\`, \`ls\`, and \`rm\`.
- No functional change: \`--region\` is already a free-form string flag and \`runCp\` / \`runLs\` / \`runRm\` / \`runDownload\` pass the value through to the API client unchanged. \`region=global\` reaches the backend the moment the backend recognises it.

Backend companion PR: CerebriumAI/dashboard-backend#3840

## Test plan

- [ ] \`go build ./...\` succeeds (verified locally)
- [ ] \`cerebrium cp --help\` shows the new example line under \`cp\`
- [ ] Same for \`download --help\`, \`ls --help\`, \`rm --help\`
- [ ] Once the backend PR is deployed to dev, \`cerebrium cp file.txt --region global\` against dev uploads to the global bucket and \`ls --region global\` lists it