### PR TITLE
feat(partner): let cerebrium.toml pin the partner image version

### DIFF
--- a/pkg/projectconfig/config.go
+++ b/pkg/projectconfig/config.go
@@ -110,10 +110,11 @@ type CustomRuntimeConfig struct {
 
 // PartnerServiceConfig represents partner service configurations
 type PartnerServiceConfig struct {
-	Name      string  `mapstructure:"name" toml:"name,omitempty"`
-	Port      *int    `mapstructure:"port" toml:"port,omitempty"`
-	ModelName *string `mapstructure:"model_name" toml:"model_name,omitempty"`
-	Language  *string `mapstructure:"language" toml:"language,omitempty"`
+	Name         string  `mapstructure:"name" toml:"name,omitempty"`
+	Port         *int    `mapstructure:"port" toml:"port,omitempty"`
+	ModelName    *string `mapstructure:"model_name" toml:"model_name,omitempty"`
+	Language     *string `mapstructure:"language" toml:"language,omitempty"`
+	ImageVersion *string `mapstructure:"image_version" toml:"image_version,omitempty"`
 }
 
 // ToPayload converts the project config to an API payload
@@ -219,6 +220,9 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		if pc.PartnerService.Language != nil {
 			payload["language"] = *pc.PartnerService.Language
 		}
+		if pc.PartnerService.ImageVersion != nil {
+			payload["imageVersion"] = *pc.PartnerService.ImageVersion
+		}
 	} else if pc.CustomRuntime != nil {
 		// Custom runtime only
 		addCustomRuntimePayload(payload, pc.CustomRuntime)
@@ -235,6 +239,9 @@ func (pc *ProjectConfig) ToPayload() map[string]any {
 		}
 		if pc.PartnerService.Language != nil {
 			payload["language"] = *pc.PartnerService.Language
+		}
+		if pc.PartnerService.ImageVersion != nil {
+			payload["imageVersion"] = *pc.PartnerService.ImageVersion
 		}
 	} else {
 		// Default cortex runtime

--- a/pkg/projectconfig/loader.go
+++ b/pkg/projectconfig/loader.go
@@ -124,6 +124,12 @@ func Load(configPath string) (*ProjectConfig, error) {
 				partnerConfig.Language = &language
 			}
 
+			// Check for image_version to pin the partner image tag (e.g., "260728")
+			if v.IsSet(key + ".image_version") {
+				imageVersion := v.GetString(key + ".image_version")
+				partnerConfig.ImageVersion = &imageVersion
+			}
+
 			config.PartnerService = partnerConfig
 			break // Only one partner service at a time
 		}

--- a/pkg/projectconfig/loader_test.go
+++ b/pkg/projectconfig/loader_test.go
@@ -300,3 +300,63 @@ func TestToPayload_Compute(t *testing.T) {
 		assert.False(t, present)
 	})
 }
+
+func TestPartnerImageVersion(t *testing.T) {
+	loadPartner := func(t *testing.T, partnerBody string) *ProjectConfig {
+		t.Helper()
+		configPath := filepath.Join(t.TempDir(), "cerebrium.toml")
+		content := `[cerebrium.deployment]
+name = "test-deepgram"
+
+[cerebrium.runtime.deepgram]
+` + partnerBody
+		require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
+
+		config, err := Load(configPath)
+		require.NoError(t, err)
+		require.NotNil(t, config.PartnerService)
+		return config
+	}
+
+	t.Run("image_version is nil when not specified", func(t *testing.T) {
+		config := loadPartner(t, "")
+		assert.Nil(t, config.PartnerService.ImageVersion)
+	})
+
+	t.Run("parses image_version", func(t *testing.T) {
+		config := loadPartner(t, "image_version = \"260416\"\n")
+		require.NotNil(t, config.PartnerService.ImageVersion)
+		assert.Equal(t, "260416", *config.PartnerService.ImageVersion)
+	})
+
+	t.Run("image_version coexists with other partner keys", func(t *testing.T) {
+		config := loadPartner(t, "port = 8080\nimage_version = \"260416\"\n")
+		require.NotNil(t, config.PartnerService.ImageVersion)
+		assert.Equal(t, "260416", *config.PartnerService.ImageVersion)
+		require.NotNil(t, config.PartnerService.Port)
+		assert.Equal(t, 8080, *config.PartnerService.Port)
+	})
+
+	t.Run("payload carries imageVersion when set", func(t *testing.T) {
+		config := loadPartner(t, "image_version = \"260416\"\n")
+		payload := config.ToPayload()
+		assert.Equal(t, "deepgram", payload["partnerService"])
+		assert.Equal(t, "260416", payload["imageVersion"])
+	})
+
+	t.Run("payload omits imageVersion when unset", func(t *testing.T) {
+		payload := loadPartner(t, "").ToPayload()
+		_, present := payload["imageVersion"]
+		assert.False(t, present)
+	})
+
+	t.Run("payload carries imageVersion alongside custom runtime", func(t *testing.T) {
+		version := "260416"
+		pc := &ProjectConfig{
+			Deployment:     DeploymentConfig{Name: "test-deepgram"},
+			CustomRuntime:  &CustomRuntimeConfig{Port: 8080},
+			PartnerService: &PartnerServiceConfig{Name: "deepgram", ImageVersion: &version},
+		}
+		assert.Equal(t, "260416", pc.ToPayload()["imageVersion"])
+	})
+}


### PR DESCRIPTION
Lets a user pin the partner container image tag from their `cerebrium.toml` instead of always taking the platform default:

```toml
[cerebrium.runtime.deepgram]
image_version = "260728"
```

Three small changes, matching how `port` / `model_name` / `language` already work:

- `ImageVersion *string` on `PartnerServiceConfig`
- parsed in the loader from `cerebrium.runtime.<partner>.image_version`
- emitted as `imageVersion` in `ToPayload()`, in both partner branches (partner-only and partner + custom runtime)

The `POST /v2/projects/{project_id}/partner-apps` endpoint already accepts `imageVersion`, so no backend change is needed — the CLI simply had no way to send it. The partner ksvc is only ever written by that create endpoint, so the toml is the effective source of truth on every deploy and the pin holds.

## Not validated client-side

Any string is passed through. A typo'd tag surfaces as an image pull failure at deploy time rather than a config error. I left it unvalidated deliberately — the backend doesn't constrain the format either, and hardcoding a date-stamp pattern here would break the moment a partner uses a different tag scheme. Happy to add a format check if you'd rather fail fast.

## Testing

New `TestPartnerImageVersion` covers: absent key → nil, parsed value, coexistence with `port`, payload includes/omits the key, and the partner + custom-runtime branch. `go build ./...`, full `go test ./...`, and `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)