### PR TITLE
fix(deploy): fail fast on non-TTY confirmation; correct login and version guidance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sebdah/goldie/v2 v2.8.0
 	github.com/spf13/cobra v1.10.1
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.17.0
@@ -51,7 +52,6 @@ require (
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -13,18 +13,18 @@ import (
 	"github.com/cerebriumai/cerebrium/pkg/projectconfig"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // NewDeployCmd creates a deploy command
 func NewDeployCmd() *cobra.Command {
 	var (
-		name                string
-		disableSyntaxCheck  bool
-		logLevel            string
-		configFile          string
-		disableConfirmation bool
-		disableBuildLogs    bool
-		detach              bool
+		name               string
+		disableSyntaxCheck bool
+		logLevel           string
+		configFile         string
+		disableBuildLogs   bool
+		detach             bool
 	)
 
 	cmd := &cobra.Command{
@@ -50,7 +50,7 @@ Example:
 				configFile:         configFile,
 				disableBuildLogs:   disableBuildLogs,
 				detach:             detach,
-			}, disableConfirmation)
+			}, confirmationDisabled(cmd.Flags()))
 		},
 	}
 
@@ -59,7 +59,8 @@ Example:
 	cmd.Flags().BoolVar(&disableSyntaxCheck, "disable-syntax-check", false, "Flag to disable syntax check")
 	cmd.Flags().StringVar(&logLevel, "log-level", "INFO", "Log level for deployment (DEBUG or INFO)")
 	cmd.Flags().StringVar(&configFile, "config-file", "./cerebrium.toml", "Path to the cerebrium config TOML file")
-	cmd.Flags().BoolVarP(&disableConfirmation, "disable-confirmation", "y", false, "Disable confirmation prompt")
+	cmd.Flags().BoolP("disable-confirmation", "y", false, "Disable confirmation prompt")
+	cmd.Flags().Bool("yes", false, "Skip the confirmation prompt (alias of --disable-confirmation)")
 	cmd.Flags().BoolVar(&disableBuildLogs, "disable-build-logs", false, "Disable build logs during deployment")
 	cmd.Flags().BoolVar(&detach, "detach", false, "Kick off deployment and exit without waiting for build completion. The build will continue on the server and Ctrl+C will not cancel it.")
 
@@ -75,6 +76,24 @@ type deployOptions struct {
 	detach             bool
 }
 
+// confirmationDisabled resolves the effective confirmation setting from
+// --disable-confirmation (-y) and its alias --yes
+func confirmationDisabled(flags *pflag.FlagSet) bool {
+	disableConfirmation, _ := flags.GetBool("disable-confirmation")
+	yes, _ := flags.GetBool("yes")
+	return disableConfirmation || yes
+}
+
+// validateConfirmationPrompt fails fast when a confirmation prompt would be
+// required but stdin is not a TTY, so a closed or piped stdin can never hang
+// the command or be mistaken for consent
+func validateConfirmationPrompt(stdinIsTTY, disableConfirmation bool) error {
+	if disableConfirmation || stdinIsTTY {
+		return nil
+	}
+	return ui.NewValidationError(fmt.Errorf("unable to prompt for confirmation: stdin is not a TTY. Re-run with -y/--yes to skip confirmation"))
+}
+
 func runDeploy(cmd *cobra.Command, opts deployOptions, disableConfirmation bool) error {
 	cmd.SilenceUsage = true
 
@@ -82,6 +101,11 @@ func runDeploy(cmd *cobra.Command, opts deployOptions, disableConfirmation bool)
 	displayOpts, err := ui.GetDisplayConfigFromContext(cmd)
 	if err != nil {
 		return ui.NewValidationError(fmt.Errorf("failed to get display options: %w", err))
+	}
+
+	// Fail fast if we would need to prompt for confirmation but cannot
+	if err := validateConfirmationPrompt(displayOpts.StdinIsTTY, disableConfirmation); err != nil {
+		return err
 	}
 
 	// Get config from context (loaded once in root command)

--- a/internal/commands/deploy_test.go
+++ b/internal/commands/deploy_test.go
@@ -1,0 +1,106 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cerebriumai/cerebrium/internal/ui"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateConfirmationPrompt(t *testing.T) {
+	tcs := []struct {
+		name                string
+		stdinIsTTY          bool
+		disableConfirmation bool
+		expectError         bool
+	}{
+		{
+			name:                "TTY with confirmation required - prompt allowed",
+			stdinIsTTY:          true,
+			disableConfirmation: false,
+			expectError:         false,
+		},
+		{
+			name:                "TTY with confirmation disabled - no prompt needed",
+			stdinIsTTY:          true,
+			disableConfirmation: true,
+			expectError:         false,
+		},
+		{
+			name:                "non-TTY with confirmation disabled - no prompt needed",
+			stdinIsTTY:          false,
+			disableConfirmation: true,
+			expectError:         false,
+		},
+		{
+			name:                "non-TTY with confirmation required - fail fast",
+			stdinIsTTY:          false,
+			disableConfirmation: false,
+			expectError:         true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConfirmationPrompt(tc.stdinIsTTY, tc.disableConfirmation)
+
+			if !tc.expectError {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+
+			var uiErr *ui.UIError
+			require.True(t, errors.As(err, &uiErr), "guard should return a structured UIError")
+			assert.Equal(t, ui.ErrorTypeValidation, uiErr.Type)
+			assert.Contains(t, err.Error(), "stdin is not a TTY")
+			assert.Contains(t, err.Error(), "-y/--yes", "error should name the flag that skips confirmation")
+		})
+	}
+}
+
+func Test_confirmationDisabled(t *testing.T) {
+	tcs := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{
+			name:     "no flags",
+			args:     []string{},
+			expected: false,
+		},
+		{
+			name:     "--disable-confirmation",
+			args:     []string{"--disable-confirmation"},
+			expected: true,
+		},
+		{
+			name:     "-y shorthand",
+			args:     []string{"-y"},
+			expected: true,
+		},
+		{
+			name:     "--yes alias",
+			args:     []string{"--yes"},
+			expected: true,
+		},
+		{
+			name:     "both flags",
+			args:     []string{"--disable-confirmation", "--yes"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewDeployCmd()
+			require.NoError(t, cmd.ParseFlags(tc.args))
+
+			assert.Equal(t, tc.expected, confirmationDisabled(cmd.Flags()))
+		})
+	}
+}

--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -1325,14 +1326,21 @@ func (m *DeployView) showDeploymentSummary() {
 	fmt.Print("Do you want to deploy? (Y/n): ")
 }
 
-// waitForConfirmation waits for user input in non-TTY mode
+// waitForConfirmation waits for user input in simple output mode
 func (m *DeployView) waitForConfirmation() tea.Msg {
-	// Read a single line from stdin
-	var response string
-	fmt.Scanln(&response) //nolint:errcheck,gosec // User input handling, errors handled by empty response default
+	return readConfirmationResponse(os.Stdin)
+}
 
-	// Default to "yes" if empty (just Enter pressed)
-	if response == "" || strings.ToLower(response) == "y" || strings.ToLower(response) == "yes" {
+// readConfirmationResponse reads a single line from r and interprets it as a
+// confirmation response. An empty line defaults to yes (the prompt is Y/n);
+// EOF or any read error is a decline so a closed stdin can never consent
+func readConfirmationResponse(r io.Reader) confirmationResponseMsg {
+	line, err := bufio.NewReader(r).ReadString('\n')
+	response := strings.ToLower(strings.TrimSpace(line))
+	if err != nil && response == "" {
+		return confirmationResponseMsg{confirmed: false}
+	}
+	if response == "" || response == "y" || response == "yes" {
 		return confirmationResponseMsg{confirmed: true}
 	}
 	return confirmationResponseMsg{confirmed: false}

--- a/internal/ui/commands/deploy_test.go
+++ b/internal/ui/commands/deploy_test.go
@@ -3,7 +3,10 @@ package commands
 import (
 	"context"
 	"errors"
+	"io"
+	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/cerebriumai/cerebrium/internal/api"
 	apimock "github.com/cerebriumai/cerebrium/internal/api/mock"
@@ -1052,4 +1055,70 @@ func TestDeployView_View(t *testing.T) {
 		// When cancelled without error, view shows "Deployment cancelled"
 		assert.Contains(t, view, "cancelled")
 	})
+}
+
+func TestReadConfirmationResponse(t *testing.T) {
+	tcs := []struct {
+		name      string
+		input     io.Reader
+		confirmed bool
+	}{
+		{
+			name:      "explicit yes",
+			input:     strings.NewReader("y\n"),
+			confirmed: true,
+		},
+		{
+			name:      "explicit yes uppercase",
+			input:     strings.NewReader("Y\n"),
+			confirmed: true,
+		},
+		{
+			name:      "explicit yes word",
+			input:     strings.NewReader("yes\n"),
+			confirmed: true,
+		},
+		{
+			name:      "yes without trailing newline",
+			input:     strings.NewReader("y"),
+			confirmed: true,
+		},
+		{
+			name:      "empty line defaults to yes",
+			input:     strings.NewReader("\n"),
+			confirmed: true,
+		},
+		{
+			name:      "whitespace-only line defaults to yes",
+			input:     strings.NewReader("   \n"),
+			confirmed: true,
+		},
+		{
+			name:      "explicit no",
+			input:     strings.NewReader("n\n"),
+			confirmed: false,
+		},
+		{
+			name:      "any other input declines",
+			input:     strings.NewReader("maybe\n"),
+			confirmed: false,
+		},
+		{
+			name:      "EOF with no input declines",
+			input:     strings.NewReader(""),
+			confirmed: false,
+		},
+		{
+			name:      "read error declines",
+			input:     iotest.ErrReader(errors.New("stdin read failure")),
+			confirmed: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := readConfirmationResponse(tc.input)
+			assert.Equal(t, tc.confirmed, msg.confirmed)
+		})
+	}
 }

--- a/internal/ui/displayconf.go
+++ b/internal/ui/displayconf.go
@@ -21,6 +21,7 @@ func GetDisplayConfigContextKey() DisplayConfigContextKey {
 type DisplayConfig struct {
 	DisableAnimation bool
 	IsInteractive    bool
+	StdinIsTTY       bool
 }
 
 func (d DisplayConfig) SimpleOutput() bool {
@@ -37,6 +38,10 @@ func NewDisplayConfig(cmd *cobra.Command, verbose bool) (DisplayConfig, error) {
 	// Detect if stdout is a TTY
 	// We only check stdout because that's where the TUI output goes
 	stdoutIsTTY := isatty.IsTerminal(os.Stdout.Fd())
+
+	// Detect if stdin is a TTY
+	// Commands that prompt for input must fail fast when it is not
+	stdinIsTTY := isatty.IsTerminal(os.Stdin.Fd())
 
 	// Check if stdout and stderr point to the same file
 	// This matters for verbose mode: if they're separate, verbose logs won't interfere with TUI
@@ -64,6 +69,7 @@ func NewDisplayConfig(cmd *cobra.Command, verbose bool) (DisplayConfig, error) {
 	opts := DisplayConfig{
 		DisableAnimation: disableAnimation,
 		IsInteractive:    isInteractive,
+		StdinIsTTY:       stdinIsTTY,
 	}
 
 	// Debug logging to help diagnose display options
@@ -74,6 +80,7 @@ func NewDisplayConfig(cmd *cobra.Command, verbose bool) (DisplayConfig, error) {
 		"disable-animation-flag", disableAnimationFlag,
 		"verbose-flag", verbose,
 		"stdout-is-tty", stdoutIsTTY,
+		"stdin-is-tty", stdinIsTTY,
 		"stderr-is-tty", isatty.IsTerminal(os.Stderr.Fd()),
 		"stderr-same-as-stdout", stderrRedirectedToStdout,
 		"verbose-forces-simple", verboseForcesSimpleOutput,


### PR DESCRIPTION
## Context

Part of Phase 0 of the Agentic Cerebrium initiative: making Cerebrium reliably drivable by coding agents. Agents and CI drive this CLI headlessly (piped stdin, no TTY). Today the deploy confirmation silently auto-confirms on stdin EOF and hangs forever on an open pipe, and two guidance messages point at an env var and a command that do not exist. Bad guidance is amplified with agents: they follow error messages literally.

This PR is layer 2 of a 2-PR chain (merge in order; the upper PR auto-retargets to main when the lower merges):
1. #88 guidance fixes (env var name, version-check command)
2. #87 deploy confirmation hardening

(Chained bases rather than a native GitHub stack: the stacked-PR public preview is not enabled on this repository.)

Phase 0 CLI track, layer 2: deploy confirmation hardening. Based on kyle/phase0-cli-guidance (#88), which carries the login/version guidance fixes that were previously part of this PR.

## Changes

- Before: `fmt.Scanln` meant EOF on stdin silently auto-confirmed a deploy, and an open non-TTY pipe blocked forever. An agent or CI piping into `cerebrium deploy` could ship to prod by accident.
- Now: `StdinIsTTY` added to `DisplayConfig` (mattn/go-isatty, already a dependency, same pattern as the existing stdout detection). When stdin is not a TTY and confirmation was not disabled, deploy fails fast before any side effects: `unable to prompt for confirmation: stdin is not a TTY. Re-run with -y/--yes to skip confirmation` (clig.dev / Azure CLI convention).
- The guard is keyed off stdin TTY-ness only, NOT SimpleOutput: `--no-color` on a real terminal still prompts.
- `fmt.Scanln` replaced by `readConfirmationResponse(io.Reader)`: EOF or read error is a decline, never consent. Plain Enter still defaults to yes on a live TTY.
- `--yes` added as a visible alias of `--disable-confirmation` (`-y` shorthand preserved), resolved through a testable `confirmationDisabled(flags)` helper.
- No agent-env detection (CLAUDECODE etc.): deliberately deferred to Phase 1; detection must never auto-confirm.

## How to test this layer

1. Unit tests: `go test ./internal/commands/... ./internal/ui/commands/...`
   - `Test_validateConfirmationPrompt`: TTY/non-TTY x confirmation required/disabled matrix, asserts the error names -y/--yes.
   - `Test_confirmationDisabled`: 5 flag combos including -y and --yes.
   - `TestReadConfirmationResponse`: 10 cases, EOF and read-error decline paths included.
   Full suite `go test ./...` passes.
2. Manual, non-TTY (the dangerous paths, both previously auto-confirmed or hung):
   - `go build -o /tmp/cerebrium-test ./cmd/cerebrium && echo | /tmp/cerebrium-test deploy` fails fast, exit 1, error names -y/--yes.
   - `/tmp/cerebrium-test deploy < /dev/null` same fail-fast (previously auto-confirmed).
   - `/tmp/cerebrium-test deploy -y` and `--yes` and `--disable-confirmation` all skip the prompt.
3. Manual, TTY: `cerebrium deploy` in a real terminal still prompts, including with `--no-color`; Ctrl-D at the prompt aborts (previously confirmed); `deploy --help` shows both --yes and --disable-confirmation.

## Notes

- golangci-lint v2.5.0 reports 4 findings, all verified pre-existing on origin/main via stash round-trip; zero new.
- `go mod tidy` promoted spf13/pflag to a direct dependency (now imported by the deploy command).
- Open question recorded in plan.md: whether other interactive (bubbletea) prompts should get the same non-TTY guard; only deploy used raw Scanln.

Stack position: 2 of 2 (kyle/phase0-cli-guidance -> kyle/phase0-agent-safe-cli). Merge #88 first, then retarget this PR to main (or let GitHub retarget on branch deletion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


