### PR TITLE
fix(logs): stop --no-follow dropping and reversing its output

### DIFF
--- a/internal/ui/logging/viewer.go
+++ b/internal/ui/logging/viewer.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -72,8 +73,8 @@ func NewLogViewer(ctx context.Context, config LogViewerConfig) *LogViewerModel {
 		config:        config,
 		state:         viewerStateInitialising,
 		spinner:       ui.NewSpinner(),
-		logChan:       make(chan []Log, 100), // Buffered to prevent blocking provider
-		doneChan:      make(chan error),
+		logChan:       make(chan []Log, 100),     // Buffered to prevent blocking provider
+		doneChan:      make(chan error, 1),       // Buffered so the provider publishes its result without waiting
 		anchorBottom:  true,                      // Auto-scroll to bottom by default
 		printedLogIDs: make(map[string]struct{}), // Track printed logs by ID
 	}
@@ -83,8 +84,6 @@ func NewLogViewer(ctx context.Context, config LogViewerConfig) *LogViewerModel {
 func (m *LogViewerModel) Init() tea.Cmd {
 	// Start provider in background goroutine
 	go func() {
-		defer close(m.logChan)
-
 		err := m.config.Provider.Collect(m.ctx, func(logs []Log) error {
 			if m.ctx.Err() != nil {
 				return m.ctx.Err()
@@ -94,16 +93,17 @@ func (m *LogViewerModel) Init() tea.Cmd {
 			m.logChan <- logs
 			return nil
 		})
-		// Provider closed - signal completion
+		// Publish the result before closing, so the reader - which learns the
+		// provider finished only from the closed channel - always finds it.
 		m.doneChan <- err
+		close(m.logChan)
 	}()
 
 	m.state = viewerStateRunning
 
 	return tea.Batch(
 		m.spinner.Init(),
-		waitForLogBatch(m.logChan),
-		waitForProviderDone(m.doneChan),
+		waitForLogBatch(m.logChan, m.doneChan),
 		tick(m.config.TickInterval),
 	)
 }
@@ -111,7 +111,16 @@ func (m *LogViewerModel) Init() tea.Cmd {
 func (m *LogViewerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case logBatchReceivedMsg:
-		for _, log := range msg.logs {
+		// A one-shot fetch pages backwards, so the batch arrives newest-first.
+		// Order it before printing: simple mode writes each line as it is
+		// appended, and stdout can't be re-sorted after the fact the way the
+		// interactive viewer re-sorts m.logs below.
+		batch := slices.Clone(msg.logs)
+		sort.SliceStable(batch, func(i, j int) bool {
+			return batch[i].Timestamp.Before(batch[j].Timestamp)
+		})
+
+		for _, log := range batch {
 			m.logs = append(m.logs, log)
 
 			// Direct output in simple mode
@@ -159,13 +168,13 @@ func (m *LogViewerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(printCmds) > 0 {
 				return m, tea.Batch(
 					tea.Sequence(printCmds...),
-					waitForLogBatch(m.logChan),
+					waitForLogBatch(m.logChan, m.doneChan),
 				)
 			}
 		}
 
 		// Keep listening for more logs
-		return m, waitForLogBatch(m.logChan)
+		return m, waitForLogBatch(m.logChan, m.doneChan)
 
 	case providerDoneMsg:
 		m.state = viewerStateFinished
@@ -174,7 +183,7 @@ func (m *LogViewerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		// Don't schedule another tick if we're done
-		if m.state == viewerStateFinished && len(m.logChan) == 0 {
+		if m.IsComplete() {
 			return m, nil
 		}
 
@@ -357,7 +366,9 @@ func (m *LogViewerModel) GetError() error {
 	return m.err
 }
 
-// IsComplete returns true if log collection has finished
+// IsComplete returns true if log collection has finished and every log it
+// produced has been handled. waitForLogBatch only reports completion after the
+// log channel drains, so reaching viewerStateFinished implies both.
 func (m *LogViewerModel) IsComplete() bool {
 	return m.state == viewerStateFinished
 }
@@ -378,15 +389,18 @@ type tickMsg time.Time
 
 // Commands
 
-func waitForLogBatch(ch <-chan []Log) tea.Cmd {
+// waitForLogBatch delivers the next batch of logs, or the provider's completion
+// once the log channel closes. Both travel the same channel on purpose: it orders
+// completion behind every log the provider emitted. Signalling completion
+// separately races with the logs, and losing that race means quitting on
+// IsComplete while a batch is still in flight, which silently drops it.
+func waitForLogBatch(logs <-chan []Log, done <-chan error) tea.Cmd {
 	return func() tea.Msg {
-		return logBatchReceivedMsg{logs: <-ch}
-	}
-}
-
-func waitForProviderDone(ch <-chan error) tea.Cmd {
-	return func() tea.Msg {
-		return providerDoneMsg{err: <-ch}
+		batch, ok := <-logs
+		if !ok {
+			return providerDoneMsg{err: <-done}
+		}
+		return logBatchReceivedMsg{logs: batch}
 	}
 }
 


### PR DESCRIPTION
Stacked on [#89](https://github.com/CerebriumAI/cerebrium/pull/89) — base is `fix/logs-nofollow-race`. Makes both of its tests pass. Touches only `viewer.go`.

**Dropped logs.** The provider signalled completion on `doneChan`, separate from the logs on `logChan`, and Bubbletea runs both waiters concurrently — so the messages raced. When `providerDoneMsg` won, `LogsView` quit on `IsComplete()` before the pending batch was rendered. A `--no-follow` fetch loses this routinely: the provider emits one batch and finishes immediately.

Fix: route completion through the log channel. The provider publishes its result, then closes `logChan`; the single waiter reports completion only once the channel drains. Ordering becomes a property of the channel rather than of scheduling, so no interleaving can drop a batch. The separate done waiter goes away.

Note a `len(logChan) == 0` guard is *not* sufficient — the waiter dequeues a batch before its message is delivered, so an in-flight batch is invisible to the channel length. That guard alone still dropped logs in 50% of runs.

**Reversed output.** Simple mode prints each line as it is appended, which happens before the sort that orders `m.logs` — so the interactive viewer rendered correctly while stdout kept the API's newest-first ordering. Fix: sort each batch on arrival, before anything is printed. The batch is cloned so the provider's slice isn't mutated.

## Verification

- Both tests fail on #89, pass here
- Full suite passes; `go test -race` clean on both packages
- `golangci-lint`: 43 issues before and after — no new ones
- Against prod: 10/10 `--no-follow` runs print all 200 lines, ascending (`10:50:23` → `10:51:34`)
- Follow mode unaffected — still streamed 1026 lines over a 25s window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
