### PR TITLE
ci(pypi): fail the release instead of publishing without binaries

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -9,7 +9,47 @@ permissions:
   contents: read
 
 jobs:
+  # This runs concurrently with the Deploy Release build, so the binaries the pip
+  # wrapper downloads on first run may not exist on the release yet.
+  wait-for-binaries:
+    name: Wait for release binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Wait for the release to carry a complete set of assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          release_is_complete() {
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --json assets --jq '.assets[].name' >assets.txt 2>/dev/null || return 1
+            grep -qx 'checksums.txt' assets.txt || return 1
+
+            gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --pattern checksums.txt --output checksums.txt --clobber 2>/dev/null || return 1
+
+            # checksums.txt lists every artifact the build produced; all must have landed
+            while read -r _ name; do
+              grep -qx "$name" assets.txt || return 1
+            done <checksums.txt
+          }
+
+          DEADLINE=$((SECONDS + 1500))
+          until release_is_complete; do
+            if [ "$SECONDS" -ge "$DEADLINE" ]; then
+              echo "ERROR: $TAG did not get a complete set of release assets in time." >&2
+              echo "The build likely failed - refusing to publish to PyPI without binaries." >&2
+              exit 1
+            fi
+            echo "Waiting for $TAG release assets..."
+            sleep 15
+          done
+
+          echo "All $(wc -l <checksums.txt) artifacts present on $TAG."
+
   build-and-publish:
+    needs: wait-for-binaries
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -82,12 +122,17 @@ jobs:
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."
 
-            if pip install cerebrium==$PYPI_VERSION; then
+            if pip install "cerebrium==$PYPI_VERSION"; then
               echo "Successfully installed cerebrium $PYPI_VERSION from PyPI"
 
               # Test that the wrapper runs (will download binary on first run)
               echo "Testing cerebrium command..."
-              cerebrium version && echo "Binary download and execution successful!"
+              if ! cerebrium version; then
+                echo "ERROR: cerebrium $PYPI_VERSION installed but failed to run." >&2
+                echo "The wrapper downloads its binary from the GitHub release on first run." >&2
+                exit 1
+              fi
+              echo "Binary download and execution successful!"
               exit 0
             else
               if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then


### PR DESCRIPTION
## Problem

`pypi-publish.yml` triggers on `release: published`, which fires when the tag is created — concurrently with the build that uploads the binaries, not after it. The pip wrapper downloads its binary from the release on first run, so the package can go live before that binary exists.

v2.5.4 hit this: the build failed, PyPI published anyway, and `pip install cerebrium` 404'd. The install test didn't catch it because `cerebrium version && echo ...` was followed by an unconditional `exit 0`, so the step could never fail.

## Changes

- Add a `wait-for-binaries` gate job: poll until every artifact in `checksums.txt` is on the release, then publish via `needs`. Times out at 25 min so a failed build goes red instead of publishing.
- Make a failed `cerebrium version` exit 1.
- Quote `pip install "cerebrium==$PYPI_VERSION"` (pre-existing SC2086 in a step already touched; file is now actionlint-clean).

Not done as a reusable workflow called from `deploy-release.yml`, which would be cleaner: PyPI doesn't support reusable workflows as trusted publishers ([warehouse#11096](https://github.com/pypi/warehouse/issues/11096)), so this must stay standalone with its trigger intact.

Gate logic verified against the real repo (complete release, missing tag, partial upload, timeout); install-test fix verified with a stub that reproduces the 404.