### PR TITLE
feat(cli): add --output json to list commands

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -383,9 +383,9 @@ func (c *client) GetApp(ctx context.Context, projectID, appID string) (*AppDetai
 	return &appDetails, nil
 }
 
-// ListContainers retrieves recent containers for an app from the v2 endpoint,
-// which is the same one the dashboard uses. The response includes pods that are
-// being torn down — distinguished by the IsTerminating field on each record.
+// ListContainers retrieves recent containers for an app. The response includes
+// containers that are being torn down — distinguished by the IsTerminating field
+// on each record.
 func (c *client) ListContainers(ctx context.Context, projectID, appID string) ([]Container, error) {
 	path := fmt.Sprintf("v2/projects/%s/apps/%s/containers", projectID, appID)
 	body, err := c.request(ctx, "GET", path, nil, true)

--- a/internal/commands/apps/get.go
+++ b/internal/commands/apps/get.go
@@ -19,10 +19,13 @@ func newGetCmd() *cobra.Command {
 
 Example:
   cerebrium apps get p-abc123
+  cerebrium apps get p-abc123 --output json
   cerebrium apps get p-abc123 --no-ansi  # Disable animations and colors`,
 		Args: cobra.ExactArgs(1),
 		RunE: runGet,
 	}
+
+	ui.AddOutputFlag(cmd)
 
 	return cmd
 }
@@ -33,6 +36,15 @@ func runGet(cmd *cobra.Command, args []string) error {
 	cmd.SilenceErrors = true
 
 	appID := args[0]
+
+	outputFormat, err := ui.ParseOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
+
+	if outputFormat == ui.OutputJSON {
+		return runGetJSON(cmd, appID)
+	}
 
 	// Get display options from context (loaded once in root command)
 	displayOpts, err := ui.GetDisplayConfigFromContext(cmd)
@@ -98,4 +110,30 @@ func runGet(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// runGetJSON bypasses the Bubbletea view and fetches the app directly, so the
+// payload is the only thing written to stdout.
+func runGetJSON(cmd *cobra.Command, appID string) error {
+	cfg, err := config.GetConfigFromContext(cmd)
+	if err != nil {
+		return ui.NewValidationError(fmt.Errorf("failed to get config: %w", err))
+	}
+
+	projectID, err := cfg.GetCurrentProject()
+	if err != nil {
+		return ui.NewValidationError(fmt.Errorf("failed to get current project: %w", err))
+	}
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return ui.NewValidationError(fmt.Errorf("failed to create API client: %w", err))
+	}
+
+	app, err := client.GetApp(cmd.Context(), projectID, appID)
+	if err != nil {
+		return ui.NewAPIError(err)
+	}
+
+	return ui.PrintJSON(app)
 }

--- a/internal/commands/apps/list.go
+++ b/internal/commands/apps/list.go
@@ -15,16 +15,24 @@ func newListCmd() *cobra.Command {
 		Short: "List all apps",
 		Long: `List all apps under your current context.
 
-Example:
-  cerebrium apps list`,
+Examples:
+  cerebrium apps list
+  cerebrium apps list --output json`,
 		RunE: runList,
 	}
+
+	ui.AddOutputFlag(cmd)
 
 	return cmd
 }
 
 func runList(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
+
+	outputFormat, err := ui.ParseOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Get config from context
 	cfg, err := config.GetConfigFromContext(cmd)
@@ -45,7 +53,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	// Show spinner while fetching
-	spinner := ui.NewSimpleSpinner("Loading apps...")
+	spinner := ui.NewSimpleSpinnerFor(outputFormat, "Loading apps...")
 	spinner.Start()
 
 	// Fetch apps
@@ -53,6 +61,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	spinner.Stop()
 	if err != nil {
 		return ui.NewAPIError(err)
+	}
+
+	if outputFormat == ui.OutputJSON {
+		return ui.PrintJSON(apps)
 	}
 
 	// Print results

--- a/internal/commands/containers/list.go
+++ b/internal/commands/containers/list.go
@@ -19,18 +19,26 @@ that are currently being torn down (shown as TERMINATING).
 
 Example:
   cerebrium containers list my-app
-  cerebrium containers list p-abc12345-my-app`,
+  cerebrium containers list p-abc12345-my-app
+  cerebrium containers list my-app --output json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd, args[0])
 		},
 	}
 
+	ui.AddOutputFlag(cmd)
+
 	return cmd
 }
 
 func runList(cmd *cobra.Command, appName string) error {
 	cmd.SilenceUsage = true
+
+	outputFormat, err := ui.ParseOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
 
 	cfg, err := config.GetConfigFromContext(cmd)
 	if err != nil {
@@ -49,13 +57,17 @@ func runList(cmd *cobra.Command, appName string) error {
 		return ui.NewValidationError(fmt.Errorf("failed to create API client: %w", err))
 	}
 
-	spinner := ui.NewSimpleSpinner("Loading containers...")
+	spinner := ui.NewSimpleSpinnerFor(outputFormat, "Loading containers...")
 	spinner.Start()
 
 	containers, err := client.ListContainers(cmd.Context(), projectID, appID)
 	spinner.Stop()
 	if err != nil {
 		return ui.NewAPIError(err)
+	}
+
+	if outputFormat == ui.OutputJSON {
+		return ui.PrintJSON(containers)
 	}
 
 	if len(containers) == 0 {

--- a/internal/commands/files/ls.go
+++ b/internal/commands/files/ls.go
@@ -22,7 +22,8 @@ func NewLsCmd() *cobra.Command {
 Examples:
   cerebrium ls                    # List all files in the root directory
   cerebrium ls sub_folder/        # List all files in a specific directory
-  cerebrium ls --region us-west-2 # List files in a specific region`,
+  cerebrium ls --region us-west-2 # List files in a specific region
+  cerebrium ls --output json`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLs(cmd, args, region)
@@ -30,12 +31,18 @@ Examples:
 	}
 
 	cmd.Flags().StringVarP(&region, "region", "r", "", "Region for the storage volume")
+	ui.AddOutputFlag(cmd)
 
 	return cmd
 }
 
 func runLs(cmd *cobra.Command, args []string, region string) error {
 	cmd.SilenceUsage = true
+
+	outputFormat, err := ui.ParseOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Default path is root
 	path := "/"
@@ -67,7 +74,7 @@ func runLs(cmd *cobra.Command, args []string, region string) error {
 	}
 
 	// Show spinner while fetching
-	spinner := ui.NewSimpleSpinner("Loading files...")
+	spinner := ui.NewSimpleSpinnerFor(outputFormat, "Loading files...")
 	spinner.Start()
 
 	// Fetch files
@@ -86,6 +93,10 @@ func runLs(cmd *cobra.Command, args []string, region string) error {
 		}
 		return files[i].Name < files[j].Name
 	})
+
+	if outputFormat == ui.OutputJSON {
+		return ui.PrintJSON(files)
+	}
 
 	// Print results
 	if len(files) == 0 {

--- a/internal/commands/projects/list.go
+++ b/internal/commands/projects/list.go
@@ -15,16 +15,24 @@ func newListCmd() *cobra.Command {
 		Short: "List all projects",
 		Long: `List all projects under your account.
 
-Example:
-  cerebrium projects list`,
+Examples:
+  cerebrium projects list
+  cerebrium projects list --output json`,
 		RunE: runList,
 	}
+
+	ui.AddOutputFlag(cmd)
 
 	return cmd
 }
 
 func runList(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
+
+	outputFormat, err := ui.ParseOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Get config from context
 	cfg, err := config.GetConfigFromContext(cmd)
@@ -39,7 +47,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	// Show spinner while fetching
-	spinner := ui.NewSimpleSpinner("Loading projects...")
+	spinner := ui.NewSimpleSpinnerFor(outputFormat, "Loading projects...")
 	spinner.Start()
 
 	// Fetch projects
@@ -47,6 +55,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	spinner.Stop()
 	if err != nil {
 		return ui.NewAPIError(err)
+	}
+
+	if outputFormat == ui.OutputJSON {
+		return ui.PrintJSON(projects)
 	}
 
 	// Print results

--- a/internal/commands/runs/list.go
+++ b/internal/commands/runs/list.go
@@ -21,7 +21,8 @@ func newListCmd() *cobra.Command {
 
 Examples:
   cerebrium runs list myapp
-  cerebrium runs list myapp --async  # Only show async runs`,
+  cerebrium runs list myapp --async  # Only show async runs
+  cerebrium runs list myapp --output json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd, args[0], asyncOnly)
@@ -29,12 +30,18 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&asyncOnly, "async", false, "Only list runs that were executed asynchronously")
+	ui.AddOutputFlag(cmd)
 
 	return cmd
 }
 
 func runList(cmd *cobra.Command, appName string, asyncOnly bool) error {
 	cmd.SilenceUsage = true
+
+	outputFormat, err := ui.ParseOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Get config from context
 	cfg, err := config.GetConfigFromContext(cmd)
@@ -58,7 +65,7 @@ func runList(cmd *cobra.Command, appName string, asyncOnly bool) error {
 	appID := normalizeAppID(projectID, appName)
 
 	// Show spinner while fetching
-	spinner := ui.NewSimpleSpinner("Loading runs...")
+	spinner := ui.NewSimpleSpinnerFor(outputFormat, "Loading runs...")
 	spinner.Start()
 
 	// Fetch runs
@@ -72,6 +79,10 @@ func runList(cmd *cobra.Command, appName string, asyncOnly bool) error {
 	sort.Slice(runs, func(i, j int) bool {
 		return runs[i].CreatedAt.After(runs[j].CreatedAt)
 	})
+
+	if outputFormat == ui.OutputJSON {
+		return ui.PrintJSON(runs)
+	}
 
 	// Print results
 	if len(runs) == 0 {

--- a/internal/commands/secrets/list.go
+++ b/internal/commands/secrets/list.go
@@ -49,6 +49,22 @@ type jsonSecret struct {
 	Value *string `json:"value,omitempty"`
 }
 
+// newJSONSecrets builds the JSON payload in the given key order. Values are
+// attached only when the caller asked to see them; without that, a name is all
+// that leaves this function.
+func newJSONSecrets(keys []string, secrets map[string]string, showValues bool) []jsonSecret {
+	out := make([]jsonSecret, 0, len(keys))
+	for _, key := range keys {
+		entry := jsonSecret{Name: key}
+		if showValues {
+			value := secrets[key]
+			entry.Value = &value
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
 func runList(cmd *cobra.Command, showValues bool, appID string) error {
 	cmd.SilenceUsage = true
 
@@ -104,16 +120,7 @@ func runList(cmd *cobra.Command, showValues bool, appID string) error {
 	sort.Strings(keys)
 
 	if outputFormat == ui.OutputJSON {
-		out := make([]jsonSecret, 0, len(keys))
-		for _, key := range keys {
-			entry := jsonSecret{Name: key}
-			if showValues {
-				value := secrets[key]
-				entry.Value = &value
-			}
-			out = append(out, entry)
-		}
-		return ui.PrintJSON(out)
+		return ui.PrintJSON(newJSONSecrets(keys, secrets, showValues))
 	}
 
 	// Handle empty secrets

--- a/internal/commands/secrets/list.go
+++ b/internal/commands/secrets/list.go
@@ -26,7 +26,8 @@ Examples:
   cerebrium secrets list                       # List project secrets (names only)
   cerebrium secrets list --show-values         # List project secrets with values
   cerebrium secrets list --app my-app          # List app-specific secrets
-  cerebrium secrets list --app my-app --show-values`,
+  cerebrium secrets list --app my-app --show-values
+  cerebrium secrets list --output json`,
 		Aliases: []string{"ls"},
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -36,12 +37,25 @@ Examples:
 
 	cmd.Flags().BoolVar(&showValues, "show-values", false, "Show secret values (hidden by default)")
 	cmd.Flags().StringVar(&appID, "app", "", "App ID to list secrets for (if not specified, lists project secrets)")
+	ui.AddOutputFlag(cmd)
 
 	return cmd
 }
 
+// jsonSecret omits Value unless --show-values was passed, so JSON output leaks no
+// more than the table does.
+type jsonSecret struct {
+	Name  string  `json:"name"`
+	Value *string `json:"value,omitempty"`
+}
+
 func runList(cmd *cobra.Command, showValues bool, appID string) error {
 	cmd.SilenceUsage = true
+
+	outputFormat, err := ui.ParseOutputFormat(cmd)
+	if err != nil {
+		return err
+	}
 
 	// Load config
 	cfg, err := config.GetConfigFromContext(cmd)
@@ -66,7 +80,7 @@ func runList(cmd *cobra.Command, showValues bool, appID string) error {
 	if appID != "" {
 		spinnerMsg = fmt.Sprintf("Loading secrets for app %s...", appID)
 	}
-	spinner := ui.NewSimpleSpinner(spinnerMsg)
+	spinner := ui.NewSimpleSpinnerFor(outputFormat, spinnerMsg)
 	spinner.Start()
 
 	// Fetch secrets (project or app level)
@@ -82,18 +96,31 @@ func runList(cmd *cobra.Command, showValues bool, appID string) error {
 		return ui.NewAPIError(err)
 	}
 
-	// Handle empty secrets
-	if len(secrets) == 0 {
-		fmt.Println("No secrets found")
-		return nil
-	}
-
 	// Sort keys for consistent output
 	keys := make([]string, 0, len(secrets))
 	for k := range secrets {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+
+	if outputFormat == ui.OutputJSON {
+		out := make([]jsonSecret, 0, len(keys))
+		for _, key := range keys {
+			entry := jsonSecret{Name: key}
+			if showValues {
+				value := secrets[key]
+				entry.Value = &value
+			}
+			out = append(out, entry)
+		}
+		return ui.PrintJSON(out)
+	}
+
+	// Handle empty secrets
+	if len(secrets) == 0 {
+		fmt.Println("No secrets found")
+		return nil
+	}
 
 	// Calculate max key width for alignment
 	maxKeyWidth := len("NAME")

--- a/internal/commands/secrets/list_test.go
+++ b/internal/commands/secrets/list_test.go
@@ -1,0 +1,64 @@
+package secrets
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Hiding values is the whole reason this payload has its own shape. If someone
+// later collapses jsonSecret into the raw map, JSON output starts printing every
+// secret in the project while the table still hides them.
+func TestNewJSONSecretsHidesValuesByDefault(t *testing.T) {
+	keys := []string{"API_KEY", "DB_PASSWORD"}
+	secrets := map[string]string{"API_KEY": "sk-live-abc123", "DB_PASSWORD": "hunter2"}
+
+	out, err := json.Marshal(newJSONSecrets(keys, secrets, false))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `[{"name":"API_KEY"},{"name":"DB_PASSWORD"}]`, string(out))
+	assert.NotContains(t, string(out), "sk-live-abc123")
+	assert.NotContains(t, string(out), "hunter2")
+}
+
+func TestNewJSONSecretsIncludesValuesWhenAsked(t *testing.T) {
+	keys := []string{"API_KEY"}
+	secrets := map[string]string{"API_KEY": "sk-live-abc123"}
+
+	out, err := json.Marshal(newJSONSecrets(keys, secrets, true))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `[{"name":"API_KEY","value":"sk-live-abc123"}]`, string(out))
+}
+
+// A secret genuinely set to "" is still a secret that exists. Encoding it through
+// a pointer keeps it distinguishable from a hidden value rather than omitted.
+func TestNewJSONSecretsKeepsEmptyValue(t *testing.T) {
+	out, err := json.Marshal(newJSONSecrets([]string{"EMPTY"}, map[string]string{"EMPTY": ""}, true))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `[{"name":"EMPTY","value":""}]`, string(out))
+}
+
+func TestNewJSONSecretsPreservesKeyOrder(t *testing.T) {
+	keys := []string{"A", "B", "C"}
+	secrets := map[string]string{"C": "3", "A": "1", "B": "2"}
+
+	result := newJSONSecrets(keys, secrets, false)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "A", result[0].Name)
+	assert.Equal(t, "B", result[1].Name)
+	assert.Equal(t, "C", result[2].Name)
+}
+
+// No secrets must encode as [] rather than null, so a consumer can iterate the
+// result without a nil check.
+func TestNewJSONSecretsEncodesEmptyAsArray(t *testing.T) {
+	out, err := json.Marshal(newJSONSecrets(nil, map[string]string{}, false))
+	require.NoError(t, err)
+
+	assert.Equal(t, "[]", string(out))
+}

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 	"time"
@@ -15,8 +14,6 @@ import (
 
 // NewStatusCmd creates a status command
 func NewStatusCmd() *cobra.Command {
-	var outputFormat string
-
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Check Cerebrium service status",
@@ -29,26 +26,24 @@ Example:
   cerebrium status
   cerebrium status --output json    # Output as JSON for automation
   cerebrium status --no-color       # Disable animations and colors`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStatus(cmd, outputFormat)
-		},
+		RunE: runStatus,
 	}
 
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table, json")
+	ui.AddOutputFlag(cmd)
 
 	return cmd
 }
 
-func runStatus(cmd *cobra.Command, outputFormat string) error {
+func runStatus(cmd *cobra.Command, _ []string) error {
 	cmd.SilenceUsage = true
 
-	// Validate output format
-	if outputFormat != "table" && outputFormat != "json" {
-		return ui.NewValidationError(fmt.Errorf("invalid output format: %s (supported: table, json)", outputFormat))
+	outputFormat, err := ui.ParseOutputFormat(cmd)
+	if err != nil {
+		return err
 	}
 
 	// For JSON output, bypass the UI and fetch data directly
-	if outputFormat == "json" {
+	if outputFormat == ui.OutputJSON {
 		return runStatusJSON(cmd)
 	}
 
@@ -191,12 +186,5 @@ func runStatusJSON(cmd *cobra.Command) error {
 		}
 	}
 
-	// Output JSON
-	jsonBytes, err := json.MarshalIndent(output, "", "  ")
-	if err != nil {
-		return ui.NewInternalError(fmt.Errorf("failed to marshal JSON: %w", err))
-	}
-
-	fmt.Println(string(jsonBytes))
-	return nil
+	return ui.PrintJSON(output)
 }

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	OutputTable = "table"
+	OutputJSON  = "json"
+)
+
+// AddOutputFlag registers the --output/-o flag on a command.
+func AddOutputFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP("output", "o", OutputTable, "Output format: table, json")
+}
+
+// ParseOutputFormat reads and validates the --output flag.
+func ParseOutputFormat(cmd *cobra.Command) (string, error) {
+	format, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return "", NewInternalError(fmt.Errorf("failed to read output flag: %w", err))
+	}
+
+	if format != OutputTable && format != OutputJSON {
+		return "", NewValidationError(fmt.Errorf("invalid output format: %s (supported: table, json)", format))
+	}
+
+	return format, nil
+}
+
+// PrintJSON writes v to stdout as indented JSON.
+func PrintJSON(v any) error {
+	jsonBytes, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return NewInternalError(fmt.Errorf("failed to marshal JSON: %w", err))
+	}
+
+	fmt.Println(string(jsonBytes))
+	return nil
+}

--- a/internal/ui/output_test.go
+++ b/internal/ui/output_test.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOutputFormat(t *testing.T) {
+	tcs := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr string
+	}{
+		{name: "defaults to table", args: nil, want: OutputTable},
+		{name: "long flag", args: []string{"--output", "json"}, want: OutputJSON},
+		{name: "short flag", args: []string{"-o", "json"}, want: OutputJSON},
+		{name: "explicit table", args: []string{"-o", "table"}, want: OutputTable},
+		{name: "unsupported format", args: []string{"-o", "yaml"}, wantErr: "invalid output format: yaml"},
+		{name: "empty format", args: []string{"-o", ""}, wantErr: "invalid output format"},
+		{name: "casing is not coerced", args: []string{"-o", "JSON"}, wantErr: "invalid output format: JSON"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
+			AddOutputFlag(cmd)
+			cmd.SetArgs(tc.args)
+			require.NoError(t, cmd.Execute())
+
+			got, err := ParseOutputFormat(cmd)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				// The message has to name the accepted values, or the caller is stuck guessing
+				assert.Contains(t, err.Error(), "table, json")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// A command that never registered the flag should surface that as an error rather
+// than silently reporting table.
+func TestParseOutputFormatWithoutFlagRegistered(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+
+	_, err := ParseOutputFormat(cmd)
+
+	assert.Error(t, err)
+}
+
+func TestPrintJSON(t *testing.T) {
+	type payload struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, PrintJSON([]payload{{Name: "a", Count: 1}}))
+	})
+
+	assert.JSONEq(t, `[{"name":"a","count":1}]`, out)
+	// Indented, so a human reading raw output can follow it
+	assert.Contains(t, out, "\n  {")
+	assert.True(t, len(out) > 0 && out[len(out)-1] == '\n', "should end with a newline")
+}
+
+// An empty slice must not print as null — consumers iterate the result directly.
+func TestPrintJSONEmptySlice(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, PrintJSON([]string{}))
+	})
+
+	assert.Equal(t, "[]\n", out)
+}
+
+func TestPrintJSONUnmarshalableValue(t *testing.T) {
+	out := captureStdout(t, func() {
+		assert.Error(t, PrintJSON(make(chan int)))
+	})
+
+	assert.Empty(t, out, "nothing should reach stdout when encoding fails")
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = original })
+
+	fn()
+
+	require.NoError(t, w.Close())
+	captured, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	return string(captured)
+}
+
+// Guards against PrintJSON drifting to a non-deterministic encoder; agents diff
+// this output between runs.
+func TestPrintJSONIsStable(t *testing.T) {
+	value := map[string]int{"b": 2, "a": 1}
+
+	first := captureStdout(t, func() { require.NoError(t, PrintJSON(value)) })
+	second := captureStdout(t, func() { require.NoError(t, PrintJSON(value)) })
+
+	assert.Equal(t, first, second)
+
+	var decoded map[string]int
+	require.NoError(t, json.Unmarshal([]byte(first), &decoded))
+	assert.Equal(t, value, decoded)
+}

--- a/internal/ui/simplespinner.go
+++ b/internal/ui/simplespinner.go
@@ -28,8 +28,21 @@ func NewSimpleSpinner(message string) *SimpleSpinner {
 	}
 }
 
+// NewSimpleSpinnerFor creates a spinner for human-facing output. It returns nil for
+// JSON output so no animation frames land in the stream carrying the payload.
+func NewSimpleSpinnerFor(outputFormat, message string) *SimpleSpinner {
+	if outputFormat == OutputJSON {
+		return nil
+	}
+	return NewSimpleSpinner(message)
+}
+
 // Start begins the spinner animation
 func (s *SimpleSpinner) Start() {
+	if s == nil {
+		return
+	}
+
 	// Only show spinner if stdout is a TTY
 	if !isatty.IsTerminal(os.Stdout.Fd()) {
 		close(s.done)
@@ -60,6 +73,10 @@ func (s *SimpleSpinner) Start() {
 
 // Stop stops the spinner animation
 func (s *SimpleSpinner) Stop() {
+	if s == nil {
+		return
+	}
+
 	close(s.stop)
 	<-s.done
 }

--- a/internal/ui/spinner_test.go
+++ b/internal/ui/spinner_test.go
@@ -74,3 +74,20 @@ func TestSpinnerModel_Update(t *testing.T) {
 	assert.NotNil(t, updatedModel, "Update should return model")
 	assert.NotNil(t, cmd, "Update should return next tick command")
 }
+
+// The JSON paths hold a nil spinner and call Start/Stop unconditionally, so a nil
+// receiver has to be a no-op rather than a panic.
+func TestSimpleSpinnerNilReceiverIsSafe(t *testing.T) {
+	var spinner *SimpleSpinner
+
+	assert.NotPanics(t, func() {
+		spinner.Start()
+		spinner.Stop()
+	})
+}
+
+func TestNewSimpleSpinnerFor(t *testing.T) {
+	assert.Nil(t, NewSimpleSpinnerFor(OutputJSON, "loading..."),
+		"JSON output must not emit spinner frames into the payload stream")
+	assert.NotNil(t, NewSimpleSpinnerFor(OutputTable, "loading..."))
+}


### PR DESCRIPTION
## Why

Coding agents are increasingly the thing running `cerebrium deploy`. To check its own work an agent has to parse our output, and today that means scraping fixed-width text tables — lossy, and they drop most of the fields the API actually returns. Only `cerebrium status` supported `--output json`.

This is the first of two PRs. The second adds a `cerebrium metrics` command for CPU / memory / GPU memory.

## What

**Shared output plumbing** — new `internal/ui/output.go` with `AddOutputFlag`, `ParseOutputFormat` and `PrintJSON`. `status` already hand-rolled exactly this; it's refactored onto the helper rather than keeping a second copy.

**`--output table|json` on** `apps list`, `apps get`, `containers list`, `runs list`, `projects list`, `secrets list`, `files ls`. Table output is byte-for-byte unchanged. JSON emits the `api` structs as-is — no reshaping, so the field names match the API.

Two details worth a look:

- `secrets list --output json` omits values unless `--show-values` is passed, so JSON leaks no more than the table does.
- The spinner is skipped for JSON (`NewSimpleSpinnerFor`, plus nil-safe `Start`/`Stop`) so no animation frames land in the stream carrying the payload. It already no-op'd on a non-TTY, so this only matters for an interactive `-o json`.

`apps get` is the one Bubbletea command here; its JSON path bypasses the view entirely and fetches directly, following the precedent `status` set. No golden files changed.

The only non-test change outside that scope is a comment reworded on `ListContainers`. Behaviour is untouched.

## Removed from this PR: the containers endpoint switch

An earlier revision of this PR also moved `containers list` from `/v2/.../containers` to `/v3/.../containers/active`, justified as matching what the web client uses. **That justification was wrong and the change has been reverted.** Recording why, since it may come up again:

- The web client's main containers table, log container filter, builds page and app headers all call **v2** — seven call sites. `/v3/containers/active` has one consumer.
- v2 is not deprecated and is entirely healthy: **117,537 prod invocations over 7 days, zero errors.**
- Critically, the v3 query filters `container_state NOT IN ('', 'Unknown', 'Failed')` — it **hides failed containers**, which is the state most worth seeing when a deploy is broken. For the agent-diagnostics use case this whole effort exists to serve, that's a regression, not an improvement.

There is a real argument for v3 that I hadn't found when I first made the change: it is **~5.7× faster at p95** (188 ms vs 1071 ms), and it excludes already-torn-down instances that v2 still reports as `RUNNING`. Both are worth having. But it's a behavioural change with a genuine trade-off and belongs in its own PR where the `Failed` exclusion is the headline — ideally alongside a backend change to stop filtering that state — rather than riding along in a PR about output formatting.

## Testing

`go build ./...`, `go vet ./...` and `go test ./...` all clean. No golden files regenerated.

Unit tests cover `ParseOutputFormat` (defaults, both flag forms, unsupported values, and that the error names the accepted formats), `PrintJSON` (indentation, trailing newline, empty slice as `[]`, nothing written when encoding fails, stable across runs), the nil-receiver spinner guard, and the secret-hiding shaping. The two behaviours that matter were mutation checked: forcing values to always be included, and removing the nil guard, each fail their test.

Verified against prod: every command above returns parseable JSON when piped with stdin closed, table output is unchanged, `-o yaml` gives a clean validation error, and `containers list` hits the v2 endpoint returning 200.

Not covered: per-command JSON output end to end. Each command calls `api.NewClient(cfg)` directly rather than taking an injected client, so there's no seam for a mock. Worth fixing, but as its own change.