### PR TITLE
fix(deploy): don't require main.py for partner service deploys

### DIFF
--- a/pkg/projectconfig/validator.go
+++ b/pkg/projectconfig/validator.go
@@ -24,13 +24,16 @@ func Validate(config *ProjectConfig) error {
 		}
 	}
 
-	// Check for main.py if not using custom runtime with dockerfile or custom entrypoint
+	// Check for main.py if not using custom runtime with dockerfile or custom entrypoint.
+	// Partner services run a prebuilt image and never package local files, so main.py
+	// is irrelevant for them.
 	hasDockerfile := config.CustomRuntime != nil && config.CustomRuntime.DockerfilePath != ""
 	hasCustomEntrypoint := config.CustomRuntime != nil &&
 		len(config.CustomRuntime.Entrypoint) > 0 &&
 		config.CustomRuntime.Entrypoint[0] != "uvicorn"
+	isPartnerService := config.PartnerService != nil
 
-	if !hasDockerfile && !hasCustomEntrypoint {
+	if !hasDockerfile && !hasCustomEntrypoint && !isPartnerService {
 		// Check if main.py exists
 		if _, err := os.Stat("main.py"); os.IsNotExist(err) {
 			if _, err := os.Stat("./main.py"); os.IsNotExist(err) {

--- a/pkg/projectconfig/validator_test.go
+++ b/pkg/projectconfig/validator_test.go
@@ -1,0 +1,53 @@
+package projectconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMainPy(t *testing.T) {
+	baseConfig := func() *ProjectConfig {
+		return &ProjectConfig{
+			Deployment: DeploymentConfig{Name: "test-app"},
+		}
+	}
+
+	t.Run("partner service does not require main.py", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		config := baseConfig()
+		config.PartnerService = &PartnerServiceConfig{Name: "deepgram"}
+
+		assert.NoError(t, Validate(config))
+	})
+
+	t.Run("partner service alongside custom runtime does not require main.py", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		config := baseConfig()
+		config.PartnerService = &PartnerServiceConfig{Name: "rime"}
+		config.CustomRuntime = &CustomRuntimeConfig{Entrypoint: []string{"uvicorn"}}
+
+		assert.NoError(t, Validate(config))
+	})
+
+	t.Run("cortex runtime still requires main.py", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		err := Validate(baseConfig())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "main.py not found")
+	})
+
+	t.Run("cortex runtime passes when main.py exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "main.py"), nil, 0644))
+		t.Chdir(tmpDir)
+
+		assert.NoError(t, Validate(baseConfig()))
+	})
+}


### PR DESCRIPTION
## Problem

Partner service deploys skip file loading, zipping and upload entirely — no local file is ever packaged. Validation demanded `main.py` anyway, so a pure partner `cerebrium.toml` fails with `main.py not found` and the user has to `touch main.py` to get past a check that never applies.

Hit while testing #74 against a real Deepgram deploy.

## Changes

- Exempt configs with a partner service from the `main.py` check in `Validate`.
- Add `validator_test.go` covering partner-only, partner + custom runtime, and the unchanged cortex cases.

## Verification

`go test ./...` and `go vet ./...` green. Confirmed against a real project directory containing only `cerebrium.toml`: the pre-fix binary exits 1 with `main.py not found`, this branch reaches the deployment confirmation screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)