### PR TITLE
fix(deploy): hide the upload step for partner service deploys

### DIFF
--- a/internal/ui/commands/deploy.go
+++ b/internal/ui/commands/deploy.go
@@ -706,8 +706,10 @@ func (m *DeployView) View() string {
 	case StateCreatingApp:
 		output.WriteString(formatStateLine(m.spinner.View(), "Creating app...", ui.ActiveStyle.Render))
 		output.WriteString("\n")
-		output.WriteString(formatStateLine("-", "Upload to Cerebrium", ui.PendingStyle.Render))
-		output.WriteString("\n")
+		if !m.isPartnerService() {
+			output.WriteString(formatStateLine("-", "Upload to Cerebrium", ui.PendingStyle.Render))
+			output.WriteString("\n")
+		}
 		output.WriteString(formatStateLine("-", "Build app", ui.PendingStyle.Render))
 		output.WriteString("\n")
 

--- a/internal/ui/commands/deploy_test.go
+++ b/internal/ui/commands/deploy_test.go
@@ -1067,6 +1067,26 @@ func TestDeployView_View(t *testing.T) {
 
 		view := model.View()
 		assert.Contains(t, view, "Creating app")
+		assert.Contains(t, view, "Upload to Cerebrium")
+	})
+
+	t.Run("view during app creation omits upload step for partner services", func(t *testing.T) {
+		model := NewDeployView(t.Context(), DeployConfig{
+			DisplayConfig: ui.DisplayConfig{
+				IsInteractive:    true,
+				DisableAnimation: false,
+			},
+			Config:    partnerConfig("partner-app"),
+			ProjectID: "test-project",
+			Client:    apimock.NewMockClient(t),
+		})
+
+		model.state = StateCreatingApp
+
+		view := model.View()
+		assert.Contains(t, view, "Creating app")
+		assert.Contains(t, view, "Build app")
+		assert.NotContains(t, view, "Upload to Cerebrium")
 	})
 
 	t.Run("view during upload", func(t *testing.T) {


### PR DESCRIPTION
## Problem

Partner deploys skip loading, zipping and upload — they go straight from create to build. The deploy checklist still rendered `Upload to Cerebrium` as a pending step under `StateCreatingApp`, advertising a stage that never runs. Same family as #74.

## Changes

- Skip the upload step line for partner services in `View()`.
- Assert the step is absent for partner deploys and still present for standard ones.

## Verification

`go test ./...` and `go vet ./...` green; no golden files affected. The spurious line is visible in the checklist captured from a real Deepgram deploy while testing #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)